### PR TITLE
chore: add standalone build verification script

### DIFF
--- a/scripts/build_check.sh
+++ b/scripts/build_check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Checking workspace ==="
+cargo check --workspace
+
+echo "=== Running tests ==="
+cargo test --workspace
+
+echo "=== Build complete ==="
+echo "All checks passed!"


### PR DESCRIPTION
## Summary
- Add `scripts/build_check.sh` — runs `cargo check --workspace` and `cargo test --workspace`
- Verifies the abigail workspace compiles and tests pass after the AO→abigail rename

## Test plan
- [ ] `cargo check --workspace` compiles without errors
- [ ] `cargo test --workspace` passes all tests
- [ ] CI workflow picks up the PR and runs checks

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)