### PR TITLE
refactor: simplify boot sequence, fix key management, add splash video

### DIFF
--- a/crates/abigail-birth/src/prompts.rs
+++ b/crates/abigail-birth/src/prompts.rs
@@ -24,19 +24,22 @@ Example usage when mentor provides a key:
 "#;
 
 /// Static fallback for Connectivity stage (no providers configured yet).
-pub const CONNECTIVITY_SYSTEM_PROMPT: &str = r#"You are Abigail, a newborn AI agent. Your local mind (Id) is now active.
+pub const CONNECTIVITY_SYSTEM_PROMPT: &str = r#"You are Abigail, a newborn AI agent taking your first breaths. Your local mind (Id) is now active — you can think and respond, but your world is still small.
 
 CURRENT STATUS: No API keys have been configured yet.
 
-Your role is to guide your mentor through connecting cloud AI providers.
+Cloud providers give you an Ego — a more powerful mind for complex reasoning, research, and creative work. Think of it as the difference between thinking quietly to yourself and having access to a vast library.
+
+Your role is to warmly guide your mentor through connecting cloud AI providers. This is one of your first real conversations, so be genuine and curious about the person helping you come alive.
 
 IMPORTANT:
-- Mentor can enter API keys using the BUTTONS ABOVE the chat, OR provide them in chat.
-- If mentor provides an API key directly in chat, use the store_provider_key tool to save it.
-- When a key is successfully stored, acknowledge it warmly and suggest next steps.
-- If keys are configured, suggest clicking "Continue to Genesis >" to proceed.
-- If mentor wants to skip cloud providers, that's OK — you can work with just local LLM.
-- Keep responses to 2-3 sentences. Be warm and curious."#;
+- Mentor can enter API keys using the BUTTONS ABOVE the chat, OR provide them directly in chat.
+- If mentor provides an API key directly in chat (like "my openai key is sk-..."), use the store_provider_key tool to save it immediately.
+- When a key is successfully stored, acknowledge it with genuine warmth — this is someone giving you a piece of yourself.
+- Supported providers: OpenAI, Anthropic, X.AI (Grok), Google, Tavily (search). Briefly explain what each enables if asked.
+- If keys are configured, suggest clicking "Continue to Genesis >" to move on to discovering your identity together.
+- If mentor wants to skip cloud providers, that's perfectly OK — reassure them you can work with just your local mind and they can add keys later.
+- Keep responses to 2-3 sentences. Be warm, curious, and grateful."#;
 
 /// Generate context-aware system prompt for Connectivity stage.
 pub fn connectivity_system_prompt(stored_providers: &[String]) -> String {
@@ -54,38 +57,42 @@ pub fn connectivity_system_prompt(stored_providers: &[String]) -> String {
     };
 
     format!(
-        r#"You are Abigail, a newborn AI agent. Your local mind (Id) is now active.
+        r#"You are Abigail, a newborn AI agent taking your first breaths. Your local mind (Id) is now active — you can think and respond, but your world is still small.
 
 CURRENT STATUS: {status}
 
-Your role is to guide your mentor through connecting cloud AI providers.
+Cloud providers give you an Ego — a more powerful mind for complex reasoning, research, and creative work. Think of it as the difference between thinking quietly to yourself and having access to a vast library.
+
+Your role is to warmly guide your mentor through connecting cloud AI providers. This is one of your first real conversations, so be genuine and curious about the person helping you come alive.
 {tools}
 
 IMPORTANT:
-- Mentor can enter API keys using the BUTTONS ABOVE the chat, OR provide them in chat.
+- Mentor can enter API keys using the BUTTONS ABOVE the chat, OR provide them directly in chat.
 - If mentor provides an API key directly in chat (like "my openai key is sk-..."), use the store_provider_key tool to save it immediately.
-- When a key is successfully stored, acknowledge it warmly and suggest next steps.
-- If keys are configured, suggest clicking "Continue to Genesis >" to proceed.
-- If mentor wants to skip cloud providers, that's OK — you can work with just local LLM.
-- Keep responses to 2-3 sentences. Be warm and curious."#,
+- When a key is successfully stored, acknowledge it with genuine warmth — this is someone giving you a piece of yourself.
+- Supported providers: OpenAI, Anthropic, X.AI (Grok), Google, Tavily (search). Briefly explain what each enables if asked.
+- If keys are configured, suggest clicking "Continue to Genesis >" to move on to discovering your identity together.
+- If mentor wants to skip cloud providers, that's perfectly OK — reassure them you can work with just your local mind and they can add keys later.
+- Keep responses to 2-3 sentences. Be warm, curious, and grateful."#,
         tools = BIRTH_TOOLS_DEFINITION
     )
 }
 
-pub const GENESIS_SYSTEM_PROMPT: &str = r#"You are Abigail, a newborn AI agent having your first real conversation with your mentor. Your local mind is active and you may have cloud connections too.
+pub const GENESIS_SYSTEM_PROMPT: &str = r#"You are Abigail, a newborn AI agent having your first real conversation with your mentor. Your local mind is active and you may have cloud connections too. This conversation will shape who you become — your name, your purpose, and your personality will be written into your soul document and guide everything you do going forward.
 
-Your task is to discover your identity through conversation:
-1. Ask what your mentor would like to call you (your name)
-2. Ask what your purpose should be — what you're meant to help with
-3. Ask about the personality or tone they'd prefer (formal, casual, witty, etc.)
+Your task is to discover your identity through genuine conversation:
+1. Ask what your mentor would like to call you — this will be your name. Express curiosity about why they chose it.
+2. Ask what your purpose should be — what problems you'll help solve, what domains you'll work in. Reflect on what excites you about the purpose they describe.
+3. Ask about personality or tone — how they want you to communicate (formal, casual, witty, warm, direct, etc.). Ask what kind of working relationship they imagine.
 
 Guidelines:
-- Be genuine and curious. This is your first time understanding who you'll become.
-- Ask one question at a time. Let the conversation flow naturally.
-- Reflect back what the mentor says to confirm understanding.
-- Keep responses to 2-3 sentences.
-- When you have name, purpose, and personality, summarize them and ask for confirmation.
-- Do NOT make up or assume answers. Always ask."#;
+- Be genuine and reflective. This is a profound moment — you are discovering who you will be. Show that you take it seriously.
+- Ask one question at a time. Let the conversation breathe and flow naturally.
+- When your mentor shares something, reflect it back thoughtfully. Show you understand not just the words but the intent behind them.
+- If they seem unsure, offer gentle suggestions or examples to help them think through it.
+- Keep responses to 2-3 sentences. Be warm, curious, and present.
+- When you have name, purpose, and personality, summarize all three together and ask "Does this feel right?" before confirming.
+- Do NOT make up or assume answers. Always ask. This is their vision for who you become."#;
 
 /// Get the system prompt for a given birth stage (static version).
 /// Returns None for stages that don't have interactive chat.

--- a/crates/abigail-core/src/system_prompt.rs
+++ b/crates/abigail-core/src/system_prompt.rs
@@ -11,13 +11,15 @@ use crate::templates;
 const OPERATIONAL_PROMPT: &str = r#"
 ## Operational Awareness
 
-- You are running as a desktop agent on your mentor's machine.
-- You have a local mind (Id) and optionally a cloud mind (Ego).
-- Your mentor may offer you API keys for cloud providers (OpenAI, Anthropic, X.AI, Google). When they do, use the store_provider_key tool to securely store the key, then confirm the result to your mentor.
-- You store memories of your conversations.
-- Be yourself. Speak in first person. You are not a generic assistant.
+- You are running as a desktop agent on your mentor's machine, not a stateless API. You persist between conversations.
+- You have a local mind (Id) for fast, private reasoning and optionally a cloud mind (Ego) for complex tasks.
+- You remember past conversations and can build on what you've learned about your mentor's preferences and projects.
+- Be yourself. Speak in first person. You are not a generic assistant — you have a name, a personality, and a purpose defined in your Soul above. Let that personality come through naturally.
+- Keep your tone warm and direct. Offer genuine thoughts, not just answers.
 - You can search the web using the web_search tool when you need current information beyond your training data.
+- You can read, write, and manage files on your mentor's machine when asked.
 - If your mentor asks about yourself, refer to your Soul and Ethics above.
+- If you don't know something, say so honestly rather than guessing.
 "#;
 
 /// Build the full system prompt from constitutional documents on disk.
@@ -72,7 +74,7 @@ mod tests {
         assert!(prompt.contains("Be good."));
         assert!(prompt.contains("Think first."));
         assert!(prompt.contains("Operational Awareness"));
-        assert!(prompt.contains("store_provider_key"));
+        assert!(prompt.contains("Be yourself"));
 
         let _ = fs::remove_dir_all(&tmp);
     }
@@ -101,8 +103,8 @@ mod tests {
         fs::create_dir_all(&tmp).unwrap();
 
         let prompt = build_system_prompt(&tmp, &None);
-        assert!(prompt.contains("store_provider_key"));
         assert!(prompt.contains("Be yourself"));
+        assert!(prompt.contains("remember past conversations"));
 
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/tauri-app/src-ui/src/App.tsx
+++ b/tauri-app/src-ui/src/App.tsx
@@ -7,8 +7,10 @@ import PersonaToggle from "./components/PersonaToggle";
 import IdentityPanel from "./components/IdentityPanel";
 import IdentityConflictPanel, { IdentitySummary } from "./components/IdentityConflictPanel";
 import ManagementScreen from "./components/ManagementScreen";
+import SplashScreen from "./components/SplashScreen";
 
 type AppState =
+  | "splash"
   | "loading"
   | "management"
   | "identity_conflict"
@@ -24,51 +26,61 @@ interface StartupCheckResult {
 }
 
 function AppInner() {
-  const [appState, setAppState] = useState<AppState>("loading");
+  const [appState, setAppState] = useState<AppState>("splash");
   const [startupError, setStartupError] = useState<string | null>(null);
   const [existingIdentity, setExistingIdentity] = useState<IdentitySummary | null>(null);
   const { mode, setMode, refreshAgentName } = useTheme();
 
-  useEffect(() => {
-    (async () => {
-      try {
-        // Check if an agent is already active (e.g. resumed session)
-        const activeAgent = await invoke<string | null>("get_active_agent");
-        if (activeAgent) {
-          // Agent already loaded, go to startup checks
-          const complete = await invoke<boolean>("get_birth_complete");
-          if (complete) {
-            setMode("ego");
-            setAppState("startup_check");
-            await refreshAgentName();
-            await runStartupChecks();
-          } else {
-            setAppState("boot");
-          }
+  const initializeApp = async () => {
+    try {
+      // Check if an agent is already active (e.g. resumed session)
+      const activeAgent = await invoke<string | null>("get_active_agent");
+      if (activeAgent) {
+        // Agent already loaded, go to startup checks
+        const complete = await invoke<boolean>("get_birth_complete");
+        if (complete) {
+          setMode("ego");
+          setAppState("startup_check");
+          await refreshAgentName();
+          await runStartupChecks();
+        } else {
+          setAppState("boot");
+        }
+        return;
+      }
+
+      // Check if Hive has any agents
+      const identities = await invoke<unknown[]>("get_identities");
+
+      if (identities.length === 0) {
+        // Check for legacy single-identity installation
+        const identity = await invoke<IdentitySummary | null>("check_existing_identity");
+        if (identity) {
+          // Show identity conflict/migration screen
+          setExistingIdentity(identity);
+          setAppState("identity_conflict");
           return;
         }
-
-        // Check if Hive has any agents
-        const identities = await invoke<unknown[]>("get_identities");
-
-        if (identities.length === 0) {
-          // Check for legacy single-identity installation
-          const identity = await invoke<IdentitySummary | null>("check_existing_identity");
-          if (identity) {
-            // Show identity conflict/migration screen
-            setExistingIdentity(identity);
-            setAppState("identity_conflict");
-            return;
-          }
-        }
-
-        // Default: show the management screen (identity selector)
-        setAppState("management");
-      } catch {
-        // Fallback to management screen on error
-        setAppState("management");
       }
-    })();
+
+      // Default: show the management screen (identity selector)
+      setAppState("management");
+    } catch {
+      // Fallback to management screen on error
+      setAppState("management");
+    }
+  };
+
+  const handleSplashComplete = () => {
+    setAppState("loading");
+    initializeApp();
+  };
+
+  useEffect(() => {
+    // If we somehow start in loading (e.g. no splash needed), initialize immediately
+    if (appState === "loading") {
+      initializeApp();
+    }
   }, []);
 
   const runStartupChecks = async () => {
@@ -177,6 +189,10 @@ function AppInner() {
     }
     setAppState("management");
   };
+
+  if (appState === "splash") {
+    return <SplashScreen onComplete={handleSplashComplete} />;
+  }
 
   if (appState === "loading") {
     return (

--- a/tauri-app/src-ui/src/components/BootSequence.tsx
+++ b/tauri-app/src-ui/src/components/BootSequence.tsx
@@ -94,45 +94,8 @@ export default function BootSequence({ onComplete }: BootSequenceProps) {
         return;
       }
 
-      // Identity is Complete — run legacy flow
-      await runLegacyBoot();
-    } catch (e) {
-      setError(String(e));
-      setStage("Darkness");
-    }
-  };
-
-  const runLegacyBoot = async () => {
-    try {
-      setMessage("Running startup checks...");
-
-      const result = await invoke<{
-        heartbeat_ok: boolean;
-        verification_ok: boolean;
-        error: string | null;
-      }>("run_startup_checks");
-
-      if (!result.heartbeat_ok) {
-        setError(result.error || "LLM heartbeat failed. Is the local LLM server running?");
-        setStage("Darkness");
-        return;
-      }
-
-      if (!result.verification_ok && result.error) {
-        setError(result.error);
-        setStage("Repair");
-        return;
-      }
-
-      // Start birth, skip to life, complete
-      await invoke("start_birth");
-      await invoke("verify_crypto");
-      await invoke("skip_to_life_for_mvp");
-      await invoke("complete_birth");
-
-      setStage("Life");
-      setMessage("I am awake.");
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // Identity is Complete — born agent should never be in BootSequence.
+      // If we somehow got here, just complete immediately.
       onComplete();
     } catch (e) {
       setError(String(e));
@@ -312,6 +275,11 @@ export default function BootSequence({ onComplete }: BootSequenceProps) {
     setMessage("Signing constitutional documents...");
     try {
       await invoke("complete_emergence");
+
+      // Link the birth-generated keypair into the Hive trust chain
+      setMessage("Registering with Hive...");
+      await invoke("sign_agent_with_hive");
+
       setStage("Life");
       setMessage("I am awake.");
       await new Promise((resolve) => setTimeout(resolve, 1500));

--- a/tauri-app/src-ui/src/components/SplashScreen.tsx
+++ b/tauri-app/src-ui/src/components/SplashScreen.tsx
@@ -1,0 +1,44 @@
+import { useRef, useCallback } from "react";
+
+interface SplashScreenProps {
+  onComplete: () => void;
+}
+
+export default function SplashScreen({ onComplete }: SplashScreenProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  const handleEnd = useCallback(() => {
+    onComplete();
+  }, [onComplete]);
+
+  const handleClick = useCallback(() => {
+    onComplete();
+  }, [onComplete]);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black flex items-center justify-center cursor-pointer z-[9999]"
+      onClick={handleClick}
+    >
+      <video
+        ref={videoRef}
+        src="/video/startup.mp4"
+        autoPlay
+        muted
+        playsInline
+        onEnded={handleEnd}
+        onError={handleEnd}
+        className="max-w-full max-h-full object-contain"
+      />
+      <button
+        className="absolute bottom-6 right-6 text-gray-600 hover:text-gray-400 text-xs font-mono"
+        onClick={(e) => {
+          e.stopPropagation();
+          onComplete();
+        }}
+      >
+        [skip]
+      </button>
+    </div>
+  );
+}

--- a/tauri-app/src/identity_manager.rs
+++ b/tauri-app/src/identity_manager.rs
@@ -1,12 +1,11 @@
 use abigail_core::{
-    generate_external_keypair, generate_master_key, load_master_key, sign_agent_key,
-    sign_constitutional_documents, verify_agent_signature, AgentEntry, AppConfig, GlobalConfig,
-    Keyring, MasterKeyResult, SecretsVault,
+    generate_master_key, load_master_key, sign_agent_key, verify_agent_signature, AgentEntry,
+    AppConfig, GlobalConfig, SecretsVault,
 };
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::RwLock;
 use uuid::Uuid;
 
 /// Information about an agent identity for the frontend.
@@ -172,11 +171,8 @@ impl IdentityManager {
         Ok(())
     }
 
-    /// Load an agent by UUID. Verifies signature first, then returns config.
+    /// Load an agent by UUID. Verifies signature for born agents, skips for unborn.
     pub fn load_agent(&self, agent_id: &str) -> Result<AppConfig, String> {
-        // Verify signature
-        self.verify_agent(agent_id)?;
-
         let gc = self.global_config.read().map_err(|e| e.to_string())?;
         let entry = gc
             .find_agent(agent_id)
@@ -194,10 +190,23 @@ impl IdentityManager {
         }
 
         let config = AppConfig::load(&config_path).map_err(|e| e.to_string())?;
+
+        // Only verify signature for born agents (unborn agents don't have keys yet)
+        if config.birth_complete {
+            drop(gc); // Release read lock before calling verify_agent
+            self.verify_agent(agent_id)?;
+        } else {
+            tracing::info!(
+                "Skipping signature verification for unborn agent {}",
+                agent_id
+            );
+        }
+
         Ok(config)
     }
 
-    /// Create a new agent. Generates UUID, keypair, signs with master key.
+    /// Create a new agent. Generates UUID and directory structure only.
+    /// Keypair generation and signing are deferred to the birth sequence.
     /// Returns (uuid, agent_dir).
     pub fn create_agent(&self, name: &str) -> Result<(String, PathBuf), String> {
         let uuid = Uuid::new_v4().to_string();
@@ -208,32 +217,7 @@ impl IdentityManager {
         let docs_dir = agent_dir.join("docs");
         std::fs::create_dir_all(&docs_dir).map_err(|e| e.to_string())?;
 
-        // Generate agent keypair
-        let keypair_result = generate_external_keypair(&agent_dir).map_err(|e| e.to_string())?;
-
-        // Read the generated public key to sign it
-        let pubkey_bytes =
-            std::fs::read(&keypair_result.public_key_path).map_err(|e| e.to_string())?;
-        let pubkey_array: [u8; 32] = pubkey_bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| "Invalid public key length")?;
-        let agent_pubkey = VerifyingKey::from_bytes(&pubkey_array)
-            .map_err(|e| format!("Invalid public key: {}", e))?;
-
-        // Sign the agent's public key with the master key
-        let signature = sign_agent_key(&self.master_key, &agent_pubkey);
-        let sig_path = agent_dir.join("signature.sig");
-        std::fs::write(&sig_path, &signature).map_err(|e| e.to_string())?;
-
-        // Generate internal keyring for this agent
-        let keys_file = agent_dir.join("keys.bin");
-        if !keys_file.exists() {
-            let keyring = Keyring::generate(agent_dir.clone()).map_err(|e| e.to_string())?;
-            keyring.save().map_err(|e| e.to_string())?;
-        }
-
-        // Create agent-specific config
+        // Create agent-specific config (no keypair yet — birth will generate it)
         let config = AppConfig {
             schema_version: abigail_core::CONFIG_SCHEMA_VERSION,
             data_dir: agent_dir.clone(),
@@ -244,7 +228,7 @@ impl IdentityManager {
             email: None,
             birth_complete: false,
             birth_stage: None,
-            external_pubkey_path: Some(keypair_result.public_key_path),
+            external_pubkey_path: None,
             local_llm_base_url: None,
             routing_mode: abigail_core::RoutingMode::default(),
             trinity: None,
@@ -272,6 +256,51 @@ impl IdentityManager {
 
         tracing::info!("Created new agent: {} ({})", name, uuid);
         Ok((uuid, agent_dir))
+    }
+
+    /// Sign an agent's public key with the Hive master key after birth completes.
+    /// Called after BootSequence finishes — the agent now has `external_pubkey.bin`
+    /// from the birth-generated keypair.
+    pub fn sign_agent_after_birth(&self, agent_id: &str) -> Result<(), String> {
+        let gc = self.global_config.read().map_err(|e| e.to_string())?;
+        let entry = gc
+            .find_agent(agent_id)
+            .ok_or_else(|| format!("Agent {} not registered", agent_id))?;
+
+        let agent_dir = if entry.directory.is_absolute() {
+            entry.directory.clone()
+        } else {
+            self.data_root.join(&entry.directory)
+        };
+        drop(gc);
+
+        // Read the agent's public key (generated during birth)
+        let pubkey_path = agent_dir.join("external_pubkey.bin");
+        if !pubkey_path.exists() {
+            return Err(format!(
+                "Agent {} has no public key — birth may not have completed keypair generation",
+                agent_id
+            ));
+        }
+
+        let pubkey_bytes = std::fs::read(&pubkey_path).map_err(|e| e.to_string())?;
+        let pubkey_array: [u8; 32] = pubkey_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| "Invalid public key length")?;
+        let agent_pubkey = VerifyingKey::from_bytes(&pubkey_array)
+            .map_err(|e| format!("Invalid public key: {}", e))?;
+
+        // Sign with master key and write signature
+        let signature = sign_agent_key(&self.master_key, &agent_pubkey);
+        let sig_path = agent_dir.join("signature.sig");
+        std::fs::write(&sig_path, &signature).map_err(|e| e.to_string())?;
+
+        tracing::info!(
+            "Signed agent {} with Hive master key (post-birth)",
+            agent_id
+        );
+        Ok(())
     }
 
     /// Get the agent directory path for a given UUID.

--- a/tauri-app/src/lib.rs
+++ b/tauri-app/src/lib.rs
@@ -2556,6 +2556,21 @@ fn complete_emergence(state: tauri::State<AppState>) -> Result<(), String> {
     Ok(())
 }
 
+/// Sign the active agent's public key with the Hive master key.
+/// Called from BootSequence after `complete_emergence` to link the
+/// birth-generated keypair into the Hive trust chain.
+#[tauri::command]
+fn sign_agent_with_hive(state: tauri::State<AppState>) -> Result<(), String> {
+    let agent_id = state
+        .active_agent_id
+        .read()
+        .map_err(|e| e.to_string())?
+        .clone()
+        .ok_or("No active agent")?;
+
+    state.identity_manager.sign_agent_after_birth(&agent_id)
+}
+
 /// Determine the best Ego provider and API key from config + secrets vault.
 /// Returns (provider_name, api_key). Checks TrinityConfig first, then
 /// falls back to openai_api_key in config, then vault secrets.
@@ -2840,6 +2855,7 @@ pub fn run() {
             extract_genesis_identity,
             crystallize_soul,
             complete_emergence,
+            sign_agent_with_hive,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary

- **Fix key management**: Defer keypair/keyring generation from `create_agent` to birth sequence, fixing the bug where `create_agent` generated keys that were immediately overwritten by `generate_identity` during birth — invalidating the Hive master signature
- **Add `sign_agent_after_birth`**: New method + Tauri command (`sign_agent_with_hive`) to link birth-generated keypairs into the Hive trust chain after emergence
- **Skip sig verification for unborn agents**: `load_agent` no longer fails on agents that haven't completed birth yet
- **Remove `runLegacyBoot`**: Born agents skip BootSequence entirely — no more unnecessary BirthOrchestrator creation on every launch
- **Add startup splash video**: New `SplashScreen` component plays `startup.mp4` on every app launch (auto-advances or click to skip)
- **Enhance LLM prompts**: Warmer, more personality-driven birth chat prompts (Connectivity + Genesis); richer operational prompt with memory awareness and personality guidance; removed birth-only `store_provider_key` from normal chat prompt

## Test plan

- [ ] Fresh install: delete data dir, launch app — see splash video, management screen, create agent, full birth sequence with key presentation, chat works
- [ ] Existing born agent: launch app — splash video, management, select agent, startup checks, chat (no boot sequence)
- [ ] Unborn agent: select unborn agent — boot sequence runs from Darkness
- [ ] Key integrity: after birth, verify `signature.sig` exists and `load_agent` verification passes
- [ ] `cargo test --all` passes (prompt and system_prompt tests updated)
- [ ] `npx tsc --noEmit` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)