### PR TITLE
ci: fix Ubuntu release build glibc cache mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,7 @@ jobs:
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           workspaces: "."
+          shared-key: release-${{ matrix.platform }}
 
       - name: Install and build frontend
         run: |


### PR DESCRIPTION
## Summary
- Add platform-specific `shared-key` to Rust cache in the Release workflow
- Fixes Ubuntu build failing with `GLIBC_2.39 not found` because cached build artifacts (compiled on a newer glibc system) were restored on `ubuntu-22.04` (glibc 2.35)
- The new key (`release-${{ matrix.platform }}`) isolates each platform's cache and avoids restoring the poisoned cache

## Test plan
- [ ] Trigger a Release workflow run and verify the Ubuntu build passes the "Build abigail-keygen binary" step
- [ ] Confirm Windows and macOS builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)