### PR TITLE
chore: add build verification script

### DIFF
--- a/scripts/build_check.sh
+++ b/scripts/build_check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Checking workspace ==="
+cargo check --workspace
+
+echo "=== Running tests ==="
+cargo test --workspace
+
+echo "=== Build complete ==="
+echo "All checks passed!"


### PR DESCRIPTION
## Summary
- Adds `scripts/build_check.sh` — a standalone build verification script that validates the project compiles and tests pass before release

## Test plan
- [ ] Run `bash scripts/build_check.sh` and verify it executes cargo build + test checks
- [ ] Confirm script exits with appropriate codes on success/failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)