### PR TITLE
fix: resolve E0505 borrow error and unused variable warnings

### DIFF
--- a/tauri-app/src/identity_manager.rs
+++ b/tauri-app/src/identity_manager.rs
@@ -341,12 +341,13 @@ impl IdentityManager {
     /// On Windows: `%USERPROFILE%\Documents\Abigail\{agent_name}\`
     /// On other platforms: `~/Documents/Abigail/{agent_name}/`
     pub fn create_documents_folder(&self, agent_id: &str) -> Result<PathBuf, String> {
-        let gc = self.global_config.read().map_err(|e| e.to_string())?;
-        let entry = gc
-            .find_agent(agent_id)
-            .ok_or_else(|| format!("Agent {} not registered", agent_id))?;
-        let agent_name = &entry.name;
-        drop(gc);
+        let agent_name = {
+            let gc = self.global_config.read().map_err(|e| e.to_string())?;
+            let entry = gc
+                .find_agent(agent_id)
+                .ok_or_else(|| format!("Agent {} not registered", agent_id))?;
+            entry.name.clone()
+        };
 
         // Sanitize the name for use as a directory (replace problematic chars)
         let safe_name: String = agent_name

--- a/tauri-app/src/lib.rs
+++ b/tauri-app/src/lib.rs
@@ -1487,7 +1487,7 @@ const ALLOWED_PROVIDER_SECRET_KEYS: &[&str] = &["openai", "anthropic", "xai", "g
 
 /// Returns the set of allowed secret keys: reserved provider names + skill-declared secret names.
 fn allowed_secret_keys(
-    registry: &SkillRegistry,
+    _registry: &SkillRegistry,
     skill_paths: &[PathBuf],
 ) -> std::collections::HashSet<String> {
     let mut allowed: std::collections::HashSet<String> = ALLOWED_PROVIDER_SECRET_KEYS
@@ -2031,7 +2031,7 @@ async fn chat_stream(
             }
         });
 
-        let request = abigail_capabilities::cognitive::CompletionRequest::simple(messages.clone());
+        let _request = abigail_capabilities::cognitive::CompletionRequest::simple(messages.clone());
         let response = router
             .route_stream(messages, tx)
             .await


### PR DESCRIPTION
## Summary

- Fix E0505 borrow-after-move in `identity_manager.rs`: clone `agent_name` before dropping the `RwLock` guard
- Prefix unused variables `registry` and `request` with `_` in `lib.rs`

These were missed by the squash merge of #31 and cause release builds to fail on all platforms.

## Test plan

- [ ] `cargo test --all` passes
- [ ] Release build succeeds on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)