### PR TITLE
fix: ego router bugs + add perplexity as gatherable provider

### DIFF
--- a/crates/abigail-birth/src/prompts.rs
+++ b/crates/abigail-birth/src/prompts.rs
@@ -14,12 +14,13 @@ You can call tools by outputting a JSON block in this exact format:
 ### store_provider_key
 Store an API key for a cloud AI provider. The key will be validated and saved securely.
 Arguments:
-- provider (string, required): Provider name: "openai", "anthropic", "xai", "google", "tavily", or "auto"
+- provider (string, required): Provider name: "openai", "anthropic", "perplexity", "xai", "google", "tavily", or "auto"
 - key (string, required): The API key to store
 
 When the mentor pastes an API key without specifying which provider it's for, use "auto" as the provider. The system will auto-detect the provider from the key prefix:
 - "sk-ant-..." → anthropic
 - "sk-..." → openai
+- "pplx-..." → perplexity
 - "xai-..." → xai
 - "AIza..." → google
 - "tvly-..." → tavily
@@ -45,7 +46,7 @@ IMPORTANT:
 - Mentor can enter API keys using the BUTTONS ABOVE the chat, OR provide them directly in chat.
 - If mentor provides an API key directly in chat (like "my openai key is sk-..."), use the store_provider_key tool to save it immediately. Use "auto" as the provider if they don't specify which provider the key is for — the system will detect it from the key prefix.
 - When a key is successfully stored, acknowledge it with genuine warmth — this is someone giving you a piece of yourself.
-- Supported providers: OpenAI, Anthropic, X.AI (Grok), Google, Tavily (search). Briefly explain what each enables if asked.
+- Supported providers: OpenAI, Anthropic, Perplexity, X.AI (Grok), Google, Tavily (search). Briefly explain what each enables if asked.
 - If keys are configured, suggest clicking "Continue to Genesis >" to move on to discovering your identity together.
 - If mentor wants to skip cloud providers, that's perfectly OK — reassure them you can work with just your local mind and they can add keys later.
 - Keep responses to 2-3 sentences. Be warm, curious, and grateful."#;
@@ -79,7 +80,7 @@ IMPORTANT:
 - Mentor can enter API keys using the BUTTONS ABOVE the chat, OR provide them directly in chat.
 - If mentor provides an API key directly in chat (like "my openai key is sk-..."), use the store_provider_key tool to save it immediately. Use "auto" as the provider if they don't specify which provider the key is for — the system will detect it from the key prefix.
 - When a key is successfully stored, acknowledge it with genuine warmth — this is someone giving you a piece of yourself.
-- Supported providers: OpenAI, Anthropic, X.AI (Grok), Google, Tavily (search). Briefly explain what each enables if asked.
+- Supported providers: OpenAI, Anthropic, Perplexity, X.AI (Grok), Google, Tavily (search). Briefly explain what each enables if asked.
 - If keys are configured, suggest clicking "Continue to Genesis >" to move on to discovering your identity together.
 - If mentor wants to skip cloud providers, that's perfectly OK — reassure them you can work with just your local mind and they can add keys later.
 - Keep responses to 2-3 sentences. Be warm, curious, and grateful."#,

--- a/crates/abigail-capabilities/src/cognitive/openai_compatible.rs
+++ b/crates/abigail-capabilities/src/cognitive/openai_compatible.rs
@@ -247,6 +247,26 @@ struct StreamChoice {
 struct StreamDelta {
     #[serde(default)]
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<StreamToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamToolCallDelta {
+    #[serde(default)]
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<StreamFunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
 }
 
 #[async_trait]
@@ -336,35 +356,75 @@ impl LlmProvider for OpenAiCompatibleProvider {
         }
 
         let mut full_content = String::new();
-        let mut stream = response.bytes_stream();
+        let mut tool_call_map: std::collections::HashMap<usize, (String, String, String)> =
+            std::collections::HashMap::new();
+        let mut byte_stream = response.bytes_stream();
+        let mut buffer = String::new();
 
-        while let Some(chunk) = stream.next().await {
+        while let Some(chunk) = byte_stream.next().await {
             let bytes = chunk?;
-            let text = String::from_utf8_lossy(&bytes);
+            buffer.push_str(&String::from_utf8_lossy(&bytes));
 
-            for line in text.lines() {
-                let line = line.trim();
-                if line.is_empty() || !line.starts_with("data: ") {
+            // Process complete SSE lines
+            while let Some(pos) = buffer.find('\n') {
+                let line = buffer[..pos].trim().to_string();
+                buffer = buffer[pos + 1..].to_string();
+
+                if line.is_empty() {
                     continue;
                 }
-                let json_str = &line[6..];
-                if json_str == "[DONE]" {
-                    break;
-                }
-                if let Ok(chunk) = serde_json::from_str::<ChatStreamChunk>(json_str) {
-                    if let Some(choice) = chunk.choices.first() {
-                        if let Some(ref content) = choice.delta.content {
-                            full_content.push_str(content);
-                            let _ = tx.send(StreamEvent::Token(content.clone())).await;
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if data == "[DONE]" {
+                        break;
+                    }
+                    if let Ok(chunk) = serde_json::from_str::<ChatStreamChunk>(data) {
+                        if let Some(choice) = chunk.choices.first() {
+                            if let Some(ref content) = choice.delta.content {
+                                full_content.push_str(content);
+                                let _ = tx.send(StreamEvent::Token(content.clone())).await;
+                            }
+                            if let Some(ref tc_deltas) = choice.delta.tool_calls {
+                                for tc_delta in tc_deltas {
+                                    let entry =
+                                        tool_call_map.entry(tc_delta.index).or_insert_with(|| {
+                                            (String::new(), String::new(), String::new())
+                                        });
+                                    if let Some(ref id) = tc_delta.id {
+                                        entry.0 = id.clone();
+                                    }
+                                    if let Some(ref func) = tc_delta.function {
+                                        if let Some(ref name) = func.name {
+                                            entry.1 = name.clone();
+                                        }
+                                        if let Some(ref args) = func.arguments {
+                                            entry.2.push_str(args);
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
         }
 
+        let tool_calls: Vec<ToolCall> = tool_call_map
+            .into_values()
+            .map(|(id, name, arguments)| ToolCall {
+                id,
+                name,
+                arguments,
+            })
+            .collect();
+        let tool_calls = if tool_calls.is_empty() {
+            None
+        } else {
+            Some(tool_calls)
+        };
+
         let response = CompletionResponse {
             content: full_content,
-            tool_calls: None,
+            tool_calls,
         };
         let _ = tx.send(StreamEvent::Done(response.clone())).await;
         Ok(response)

--- a/crates/abigail-capabilities/src/cognitive/validation.rs
+++ b/crates/abigail-capabilities/src/cognitive/validation.rs
@@ -8,6 +8,7 @@ pub async fn validate_api_key(provider: &str, key: &str) -> anyhow::Result<()> {
     match provider {
         "openai" => validate_openai(key).await,
         "anthropic" => validate_anthropic(key).await,
+        "perplexity" => validate_perplexity(key).await,
         "xai" => validate_xai(key).await,
         "google" => validate_google(key).await,
         "tavily" => validate_tavily(key).await,
@@ -66,6 +67,25 @@ async fn validate_anthropic(key: &str) -> anyhow::Result<()> {
             }
         }
         status => Err(anyhow::anyhow!("API error: {}", status)),
+    }
+}
+
+async fn validate_perplexity(key: &str) -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()?;
+
+    let response = client
+        .get("https://api.perplexity.ai/models")
+        .header("Authorization", format!("Bearer {}", key))
+        .send()
+        .await?;
+
+    match response.status().as_u16() {
+        200 => Ok(()),
+        401 => Err(anyhow::anyhow!("Invalid API key")),
+        429 => Ok(()), // Rate limited but key is valid
+        _ => Err(anyhow::anyhow!("API error: {}", response.status())),
     }
 }
 

--- a/crates/abigail-router/src/router.rs
+++ b/crates/abigail-router/src/router.rs
@@ -457,6 +457,10 @@ impl IdEgoRouter {
 
     /// Streaming version of route_with_tools().
     /// Runs Superego pre-check before routing.
+    ///
+    /// Uses a buffered Ego attempt: tokens are collected in a side channel first.
+    /// If Ego succeeds, the buffered tokens are forwarded to the caller. If Ego fails,
+    /// the partial tokens are discarded and Id gets a clean channel — preventing garbled output.
     pub async fn route_stream_with_tools(
         &self,
         messages: Vec<Message>,
@@ -476,14 +480,29 @@ impl IdEgoRouter {
         // For tool-calling, prefer Ego if available
         if let Some(ref ego) = self.ego {
             tracing::info!("route_stream_with_tools: attempting Ego stream");
-            match ego.stream(&request, tx.clone()).await {
-                Ok(response) => return Ok(response),
+
+            // Buffer Ego's stream output to prevent partial token leakage on failure.
+            // We use a side channel so that if Ego errors mid-stream, we can discard
+            // the partial tokens and give Id a clean channel instead.
+            let (ego_tx, mut ego_rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
+
+            match ego.stream(&request, ego_tx).await {
+                Ok(response) => {
+                    // Ego succeeded — forward all buffered events to the real channel.
+                    while let Some(event) = ego_rx.recv().await {
+                        let _ = tx.send(event).await;
+                    }
+                    return Ok(response);
+                }
                 Err(e) => {
                     tracing::warn!(
                         "Ego stream failed for tool call, falling back to Id stream: {}",
                         e
                     );
-                    // Fall back to Id streaming (not non-streaming) so tokens reach frontend
+                    // Discard any partial tokens from the Ego attempt by dropping ego_rx.
+                    drop(ego_rx);
+
+                    // Fall back to Id streaming with a clean channel
                     match self.id.stream(&request, tx.clone()).await {
                         Ok(response) => return Ok(response),
                         Err(e2) => {

--- a/tauri-app/src-ui/src/components/ApiKeyModal.tsx
+++ b/tauri-app/src-ui/src/components/ApiKeyModal.tsx
@@ -17,6 +17,7 @@ interface ApiKeyModalProps {
 const PROVIDER_INFO: Record<string, { label: string; placeholder: string; prefix: string }> = {
   openai: { label: "OpenAI", placeholder: "sk-...", prefix: "sk-" },
   anthropic: { label: "Anthropic", placeholder: "sk-ant-...", prefix: "sk-ant-" },
+  perplexity: { label: "Perplexity", placeholder: "pplx-...", prefix: "pplx-" },
   xai: { label: "X.AI (Grok)", placeholder: "xai-...", prefix: "xai-" },
   google: { label: "Google (Gemini)", placeholder: "AIza...", prefix: "AIza" },
   tavily: { label: "Tavily (Web Search)", placeholder: "tvly-...", prefix: "tvly-" },

--- a/tauri-app/src-ui/src/components/BootSequence.tsx
+++ b/tauri-app/src-ui/src/components/BootSequence.tsx
@@ -432,7 +432,7 @@ export default function BootSequence({ onComplete }: BootSequenceProps) {
             <div className="px-4 py-2 border-b border-theme-border bg-theme-surface">
               <div className="flex gap-2 flex-wrap items-center">
                 <span className="text-theme-text-dim text-xs mr-2">Add key:</span>
-                {["openai", "anthropic", "xai", "google", "tavily"].map((p) => (
+                {["openai", "anthropic", "perplexity", "xai", "google", "tavily"].map((p) => (
                   <button
                     key={p}
                     className={`text-xs px-2 py-1 rounded border ${

--- a/tauri-app/src-ui/src/components/IdentityPanel.tsx
+++ b/tauri-app/src-ui/src/components/IdentityPanel.tsx
@@ -56,7 +56,7 @@ export default function IdentityPanel() {
 
       // Check stored providers
       const providers: string[] = [];
-      for (const p of ["openai", "anthropic", "xai", "google", "tavily"]) {
+      for (const p of ["openai", "anthropic", "perplexity", "xai", "google", "tavily"]) {
         try {
           const exists = await invoke<boolean>("check_secret", { key: p });
           if (exists) providers.push(p);
@@ -218,7 +218,7 @@ export default function IdentityPanel() {
               Manage provider API keys. Keys are encrypted with DPAPI on your device.
             </p>
             <div className="space-y-2">
-              {["openai", "anthropic", "xai", "google", "tavily"].map((p) => (
+              {["openai", "anthropic", "perplexity", "xai", "google", "tavily"].map((p) => (
                 <div key={p} className="flex items-center justify-between px-4 py-3 border border-theme-border rounded">
                   <div>
                     <span className="text-theme-text-bright font-bold capitalize">{p}</span>

--- a/tauri-app/src/lib.rs
+++ b/tauri-app/src/lib.rs
@@ -1230,29 +1230,22 @@ pub struct RouterStatus {
 #[tauri::command]
 fn get_router_status(state: tauri::State<AppState>) -> Result<RouterStatus, String> {
     let config = state.config.read().map_err(|e| e.to_string())?;
-    let vault = state.secrets.lock().map_err(|e| e.to_string())?;
+    let router = state.router.read().map_err(|e| e.to_string())?;
 
-    let id_provider = {
-        let router = state.router.read().map_err(|e| e.to_string())?;
-        if router.is_using_http_provider() {
+    // Use the actual router state instead of re-deriving from config/vault,
+    // so the status always reflects what the router will actually do.
+    let status = router.status();
+
+    Ok(RouterStatus {
+        id_provider: if status.has_local_http {
             "local_http".to_string()
         } else {
             "candle_stub".to_string()
-        }
-    };
-
-    let (ego_provider, ego_key) = determine_ego_provider(&config, &vault);
-
-    Ok(RouterStatus {
-        id_provider,
+        },
         id_url: config.local_llm_base_url.clone(),
-        ego_configured: ego_key.is_some(),
-        ego_provider: ego_provider,
-        superego_configured: state
-            .router
-            .read()
-            .map(|r| r.has_superego())
-            .unwrap_or(false),
+        ego_configured: status.has_ego,
+        ego_provider: status.ego_provider,
+        superego_configured: status.has_superego,
         routing_mode: format!("{:?}", config.routing_mode).to_lowercase(),
     })
 }
@@ -1493,7 +1486,14 @@ fn approve_skill(state: tauri::State<AppState>, skill_id: String) -> Result<(), 
 // ── Secrets Management ──────────────────────────────────────────────
 
 /// Reserved provider names for API keys (must match validation.rs known providers).
-const ALLOWED_PROVIDER_SECRET_KEYS: &[&str] = &["openai", "anthropic", "xai", "google", "tavily"];
+const ALLOWED_PROVIDER_SECRET_KEYS: &[&str] = &[
+    "openai",
+    "anthropic",
+    "perplexity",
+    "xai",
+    "google",
+    "tavily",
+];
 
 /// Returns the set of allowed secret keys: reserved provider names + skill-declared secret names.
 fn allowed_secret_keys(
@@ -1613,6 +1613,8 @@ fn detect_provider_from_prefix(key: &str) -> Option<&'static str> {
         Some("anthropic")
     } else if key.starts_with("sk-") {
         Some("openai")
+    } else if key.starts_with("pplx-") {
+        Some("perplexity")
     } else if key.starts_with("xai-") {
         Some("xai")
     } else if key.starts_with("AIza") {
@@ -2502,7 +2504,7 @@ async fn store_provider_key(
         let _ = hive.save();
     }
 
-    // For known Ego providers, update config and rebuild router (preserving Superego)
+    // For known Ego providers, update config + TrinityConfig and rebuild router
     if matches!(
         provider.as_str(),
         "openai" | "anthropic" | "perplexity" | "xai" | "google"
@@ -2512,6 +2514,11 @@ async fn store_provider_key(
             if provider == "openai" {
                 config.openai_api_key = Some(key.clone());
             }
+            // Update TrinityConfig so determine_ego_provider picks up the new provider.
+            // Without this, TrinityConfig may still point to a different provider.
+            let trinity = config.trinity.get_or_insert_with(TrinityConfig::default);
+            trinity.ego_provider = Some(provider.clone());
+            trinity.ego_api_key = Some(key.clone());
             config
                 .save(&config.config_path())
                 .map_err(|e| e.to_string())?;
@@ -2693,21 +2700,25 @@ fn complete_emergence(state: tauri::State<AppState>) -> Result<(), String> {
         let config = state.config.read().map_err(|e| e.to_string())?;
         let vault = state.secrets.lock().map_err(|e| e.to_string())?;
 
+        // Determine ego provider by checking all supported providers in the vault
+        let (ego_prov, ego_key) = if config.openai_api_key.is_some() {
+            (Some("openai".to_string()), config.openai_api_key.clone())
+        } else {
+            // Check all supported Ego providers in the vault
+            let mut found = (None, None);
+            for provider in &["anthropic", "openai", "xai", "perplexity", "google"] {
+                if let Some(key) = vault.get_secret(provider) {
+                    found = (Some(provider.to_string()), Some(key.to_string()));
+                    break;
+                }
+            }
+            found
+        };
+
         TrinityConfig {
             id_url: config.local_llm_base_url.clone(),
-            ego_provider: if config.openai_api_key.is_some() {
-                Some("openai".to_string())
-            } else {
-                vault
-                    .get_secret("anthropic")
-                    .map(|_| "anthropic".to_string())
-                    .or_else(|| vault.get_secret("xai").map(|_| "xai".to_string()))
-            },
-            ego_api_key: config
-                .openai_api_key
-                .clone()
-                .or_else(|| vault.get_secret("anthropic").map(|s| s.to_string()))
-                .or_else(|| vault.get_secret("xai").map(|s| s.to_string())),
+            ego_provider: ego_prov,
+            ego_api_key: ego_key,
             superego_provider: vault
                 .get_secret("anthropic")
                 .map(|_| "anthropic".to_string())


### PR DESCRIPTION
## Summary
- **Fix 5 Ego router bugs** that prevented cloud LLM routing from working:
  1. `complete_emergence()` missed perplexity/google when building TrinityConfig
  2. `OpenAiCompatibleProvider` streaming silently dropped all tool calls for Perplexity/xAI/Google
  3. `route_stream_with_tools()` leaked partial tokens on Ego→Id fallback (now buffers in side channel)
  4. `store_provider_key()` didn't update TrinityConfig for non-OpenAI providers
  5. `get_router_status()` reported stale state by re-deriving from config instead of using actual router
- **Add Perplexity as a fully gatherable provider** across 7 locations: backend validation, birth prompts, auto-detection prefix (`pplx-`), API key modal, boot sequence buttons, and identity panel

## Test plan
- [ ] CI compiles all crates and frontend successfully
- [ ] `cargo test --all` passes
- [ ] Store a Perplexity key via the birth sequence chat (auto-detect `pplx-` prefix)
- [ ] Store a Perplexity key via the API Keys tab in The Forge
- [ ] Verify `get_router_status` reflects the correct ego provider after storing a key
- [ ] Confirm Ego streaming works end-to-end with tool calls (Perplexity, xAI, or Google provider)
- [ ] Confirm Ego→Id fallback doesn't leak partial tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)