### PR TITLE
fix: add missing config fields in identity_manager for release build

### DIFF
--- a/tauri-app/src/identity_manager.rs
+++ b/tauri-app/src/identity_manager.rs
@@ -242,6 +242,11 @@ impl IdentityManager {
             approved_skill_ids: Default::default(),
             trusted_skill_signers: Default::default(),
             sao_endpoint: None,
+            tier_models: None,
+            provider_catalog: Vec::new(),
+            active_provider_preference: None,
+            superego_l2_mode: Default::default(),
+            email_accounts: Vec::new(),
         };
         let config_path = agent_dir.join("config.json");
         config.save(&config_path).map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary
- Adds missing v5+ `AppConfig` fields (`tier_models`, `provider_catalog`, `active_provider_preference`, `superego_l2_mode`, `email_accounts`) to the struct literal in `identity_manager.rs:224`
- These fields were added to `AppConfig` in PR #43 but `identity_manager.rs` was not updated, causing the release build to fail on all 3 platforms
- CI tests don't catch this because `abigail-app` is excluded (`--exclude abigail-app`), but the release workflow compiles the full Tauri app

## Root cause
The release workflow (run [22085373022](https://github.com/jbcupps/abigail/actions/runs/22085373022)) failed with:
```
error[E0063]: missing fields `active_provider_preference`, `email_accounts`, `provider_catalog` and 2 other fields in initializer of `abigail_core::AppConfig`
  --> tauri-app/src/identity_manager.rs:224:22
```

## Test plan
- [ ] CI passes (lint, test, frontend build)
- [ ] Release workflow builds successfully on all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)