### PR TITLE
fix: resolve lifetime error in exit handler and unused import

### DIFF
--- a/tauri-app/src/lib.rs
+++ b/tauri-app/src/lib.rs
@@ -4694,7 +4694,7 @@ pub fn run() {
                     if let Some(ref mut manager) = *guard {
                         manager.shutdown();
                     }
-                }
+                };
             }
         });
 }

--- a/tauri-app/src/ollama_manager.rs
+++ b/tauri-app/src/ollama_manager.rs
@@ -137,7 +137,6 @@ impl OllamaManager {
         // Windows: hide the console window
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
             const CREATE_NO_WINDOW: u32 = 0x0800_0000;
             cmd.creation_flags(CREATE_NO_WINDOW);
         }


### PR DESCRIPTION
## Summary
- Add semicolon after `if let` block in the app exit handler so the `MutexGuard` temporary is dropped before the `state` binding (fixes `E0597` lifetime error that broke the release build)
- Remove unnecessary `std::os::windows::process::CommandExt` import since `tokio::process::Command` already provides `creation_flags` on Windows

## Context
The release build (triggered after merging PR #46) failed on the Windows `tauri build` step with:
```
error[E0597]: `state` does not live long enough
    --> tauri-app/src/lib.rs:4693
```

## Test plan
- [ ] CI gate passes (lint, test on all 3 platforms, frontend build)
- [ ] Release workflow builds successfully on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)