### PR TITLE
ci: add cargo check for abigail-app to catch compilation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ concurrency:
 
 jobs:
 
-  # -- Lint (fast) -----------------------------------------------------------
-  # No Linux GUI deps needed: fmt and clippy only.
+  # -- Lint ----------------------------------------------------------------
+  # Checks formatting, clippy, and abigail-app compilation.
   lint:
     runs-on: ubuntu-22.04
     steps:
@@ -45,6 +45,20 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --workspace --exclude abigail-app -- -D warnings
+
+      # abigail-app is excluded from clippy/test because it needs Tauri and
+      # platform GUI libs to link.  A plain `cargo check` still catches type
+      # errors, lifetime issues, and missing imports without linking.
+      - name: Install Linux dependencies (for abigail-app check)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev build-essential curl wget file \
+            libxdo-dev libssl-dev libayatana-appindicator3-dev \
+            librsvg2-dev patchelf libgtk-3-dev
+
+      - name: Check abigail-app compiles
+        run: cargo check -p abigail-app
 
   # -- Tests (3-platform matrix) ----------------------------------------------
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,17 @@ cargo fmt --all -- --check
 # 2. Clippy (must pass with -D warnings; excludes abigail-app which needs Tauri)
 cargo clippy --workspace --exclude abigail-app -- -D warnings
 
-# 3. Tests (excludes abigail-app; runs on all 3 platforms in CI)
+# 3. Check abigail-app compiles (excluded from clippy/test but checked separately in CI)
+cargo check -p abigail-app
+
+# 4. Tests (excludes abigail-app; runs on all 3 platforms in CI)
 cargo test --workspace --exclude abigail-app
 
-# 4. Frontend build (tsc type-check + vite build)
+# 5. Frontend build (tsc type-check + vite build)
 cd tauri-app/src-ui && npm run build
 ```
 
-If any of these fail locally, fix them before pushing. The `gate` CI job will block the PR until all four pass.
+If any of these fail locally, fix them before pushing. The `gate` CI job will block the PR until all five pass.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- Add `cargo check -p abigail-app` step to the CI lint job so compilation errors in the Tauri app crate are caught in PR checks, not just release builds
- Install Linux GUI dependencies in the lint job to support the check
- Update CLAUDE.md pre-push checklist to include the new step (#3)

## Context
The `abigail-app` crate was excluded from both `cargo clippy` and `cargo test` in CI because it requires Tauri and platform-specific GUI libraries to link. This meant errors like missing trait imports (PR #46) and lifetime issues (PR #47) only surfaced during the release build — after code was already merged to main.

`cargo check` performs full type-checking and borrow-checking without linking, so it catches these errors without needing a full Tauri build.

## Test plan
- [ ] CI lint job now includes "Check abigail-app compiles" step
- [ ] The step passes on this PR (proving it works on current main)
- [ ] Introduce a deliberate compilation error in lib.rs → CI should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)