### PR TITLE
Document repeatable release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -750,11 +750,28 @@ jobs:
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
-      - name: Publish to npm
+      - name: Publish npm package (optional)
         if: steps.assets.outputs.count != '0'
         working-directory: npm-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish --access public || echo "WARNING: npm publish failed (token may not be configured)"
-          echo "Published abigail-desktop@${{ steps.npm_version.outputs.version }} to npm"
+          set -euo pipefail
+
+          VERSION="${{ steps.npm_version.outputs.version }}"
+
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::notice::NPM_TOKEN is not configured; skipping optional npm publish."
+            exit 0
+          fi
+
+          if npm view "abigail-desktop@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::abigail-desktop@${VERSION} already exists on npm; skipping publish."
+            exit 0
+          fi
+
+          if npm publish --access public; then
+            echo "Published abigail-desktop@${VERSION} to npm"
+          else
+            echo "::warning::Optional npm publish failed. GitHub release assets were already published."
+          fi

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ No accounts. No data sharing. Just your family and the Entities you control.
 - Legacy migration and upgrade preservation are not current product promises. Remove or replace stale compatibility paths when they get in the way of the active Hive-first design.
 - The stabilization lane is moving toward two parallel desktop app roots: `Abigail Hive` for control-plane/admin work and `Abigail Entity Runtime` for chat/runtime work.
 - Default local builds and installer validation are intentionally unsigned and updater-free during stabilization. Final OV signing happens later on the dedicated release-signing system.
+- Repeatable release automation is documented in [`docs/RELEASE_RUNBOOK.md`](docs/RELEASE_RUNBOOK.md). The active full installer release lane currently builds Windows and Ubuntu packages only; Apple/macOS builds are temporarily removed from the matrix.
 
 ## Dev Start
 

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -1,0 +1,69 @@
+# Abigail Release Runbook
+
+This repo has two repeatable GitHub Actions release lanes.
+
+## Full Installer Release
+
+Workflow: `Beta Release (Signed)` (`.github/workflows/release.yml`)
+
+Current active platforms:
+
+- Windows x64 NSIS installer: `Abigail-windows-x64-setup.exe`
+- Windows x64 MSI installer: `Abigail-windows-x64.msi`
+- Ubuntu 22.04+ x64 Debian package: `Abigail-linux-x64.deb`
+
+macOS/Apple builds are temporarily removed from the active build matrix. The dormant macOS steps remain in the workflow so the lane can be restored later by re-adding the macOS matrix entry after the Apple Developer agreement/signing issue is resolved.
+
+Run a specific release:
+
+```bash
+gh workflow run release.yml --ref main -f release_version=0.0.73
+```
+
+Run the next patch release automatically:
+
+```bash
+gh workflow run release.yml --ref main
+```
+
+Watch the newest run:
+
+```bash
+gh run watch --repo jbcupps/abigail
+```
+
+Verify the release:
+
+```bash
+gh release view v0.0.73 --json tagName,url,publishedAt,assets
+```
+
+The workflow creates the `vX.Y.Z` tag if it does not already exist, uploads stable asset names to the GitHub Release, and publishes the release only after both active platform builds succeed.
+
+## Repository Switches
+
+The repeatable stabilization release path keeps signing and updater artifacts opt-in.
+
+- `ABIGAIL_REQUIRE_WINDOWS_SIGNING=true` enables Windows signing checks and signing config.
+- `ABIGAIL_WINDOWS_SIGNING_MODE=store` expects a certificate available on the Windows runner.
+- `ABIGAIL_WINDOWS_RUNNER` can route Windows builds to a self-hosted runner label.
+- `ABIGAIL_REQUIRE_UPDATER_SIGNING=true` enables Tauri updater artifacts and `latest.json`.
+- `NPM_TOKEN` is optional. If present, the workflow attempts to publish `abigail-desktop`; if absent or the version already exists, GitHub release publishing still succeeds.
+
+Current expected repeat-build posture:
+
+- Leave `ABIGAIL_REQUIRE_WINDOWS_SIGNING` unset unless the signing machine is ready.
+- Leave `ABIGAIL_REQUIRE_UPDATER_SIGNING` unset until the updater signing lane is intentionally restored.
+- Keep Apple/macOS out of the build matrix until the Apple Developer account agreement/signing problem is fixed.
+
+## Unsigned Stabilization Build
+
+Workflow: `Stabilization Build (Unsigned)` (`.github/workflows/release-fast.yml`)
+
+Use it for quick Windows/Linux binary checks without installers, updater artifacts, signing, or Apple notarization:
+
+```bash
+gh workflow run release-fast.yml --ref main -f release_version=0.0.73 -f publish_prerelease=false
+```
+
+Set `publish_prerelease=true` only when you want those unsigned binaries published as a GitHub pre-release.

--- a/npm-package/bin/run.js
+++ b/npm-package/bin/run.js
@@ -76,24 +76,13 @@ function launch(binaryPath, meta) {
       break;
 
     case "darwin":
-      // For .dmg, try the Applications folder first
-      const macAppPath = "/Applications/Abigail.app";
-      if (fs.existsSync(macAppPath)) {
-        spawn("open", ["-a", macAppPath, "--args", ...args], {
-          stdio: "inherit",
-        });
-      } else {
-        // Mount and open the dmg
-        console.log(
-          "Abigail is not installed yet. Opening the disk image..."
-        );
-        spawn("open", [binaryPath], { stdio: "inherit" });
-      }
+      console.error("macOS builds are temporarily unavailable.");
+      process.exit(1);
       break;
 
     case "linux":
-      // AppImage is directly executable
-      spawn(binaryPath, args, {
+      console.log("Opening the Abigail Debian installer...");
+      spawn("xdg-open", [binaryPath], {
         stdio: "inherit",
         detached: true,
       }).unref();

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -9,7 +9,6 @@
     "postinstall": "node scripts/install.js"
   },
   "os": [
-    "darwin",
     "linux",
     "win32"
   ],

--- a/npm-package/scripts/install.js
+++ b/npm-package/scripts/install.js
@@ -9,7 +9,6 @@
 const fs = require("fs");
 const path = require("path");
 const https = require("https");
-const { execSync } = require("child_process");
 
 const pkg = require("../package.json");
 const version = pkg.version;
@@ -19,9 +18,14 @@ const version = pkg.version;
 // ---------------------------------------------------------------------------
 
 const PLATFORM_MAP = {
-  win32: { ext: "msi", archMap: { x64: "x64", arm64: "arm64" } },
-  darwin: { ext: "dmg", archMap: { x64: "universal", arm64: "universal" } },
-  linux: { ext: "AppImage", archMap: { x64: "x64", arm64: "arm64" } },
+  win32: {
+    assetName: "Abigail-windows-x64.msi",
+    archMap: { x64: "x64" },
+  },
+  linux: {
+    assetName: "Abigail-linux-x64.deb",
+    archMap: { x64: "x64" },
+  },
 };
 
 function getPlatformInfo() {
@@ -43,7 +47,7 @@ function getPlatformInfo() {
   return {
     platform,
     arch: mappedArch,
-    ext: info.ext,
+    filename: info.assetName,
   };
 }
 
@@ -92,9 +96,8 @@ function download(url, destPath, redirectCount = 0) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { platform, arch, ext } = getPlatformInfo();
+  const { platform, arch, filename } = getPlatformInfo();
 
-  const filename = `abigail_${version}_${arch}.${ext}`;
   const url = `https://github.com/jbcupps/abigail/releases/download/v${version}/${filename}`;
 
   // Determine install directory: place the binary next to this package


### PR DESCRIPTION
## Summary
- add a release runbook for the full installer and unsigned stabilization lanes
- make optional npm publishing idempotent and truthful in the release workflow
- align the npm installer package with the current Windows/Linux-only release assets while macOS is temporarily removed

## Validation
- node --check npm-package/scripts/install.js
- node --check npm-package/bin/run.js
- npm pack --dry-run (npm-package)
- cargo metadata --locked --format-version=1
- git diff --check
- gh workflow list --all