### PR TITLE
Add Abigail UI style guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No accounts. No data sharing. Just your family and the Entities you control.
 - The stabilization lane is moving toward two parallel desktop app roots: `Abigail Hive` for control-plane/admin work and `Abigail Entity Runtime` for chat/runtime work.
 - Default local builds and installer validation are intentionally unsigned and updater-free during stabilization. Final OV signing happens later on the dedicated release-signing system.
 - Repeatable release automation is documented in [`docs/RELEASE_RUNBOOK.md`](docs/RELEASE_RUNBOOK.md). The active full installer release lane currently builds Windows and Ubuntu packages only; Apple/macOS builds are temporarily removed from the matrix.
+- UI and UX work must follow the Abigail design system in [`docs/design/README.md`](docs/design/README.md).
 
 ## Dev Start
 

--- a/docs/design/01-visual-style-guide.md
+++ b/docs/design/01-visual-style-guide.md
@@ -1,0 +1,179 @@
+# Visual Style Guide
+
+Abigail should look like a private home-control surface: quiet, confident, legible, and warm enough for non-technical family members. The default UI must not resemble an unstyled admin page, terminal dump, raw HTML form, or database registry.
+
+## Brand Position
+
+- Product name: `Abigail`
+- Control-plane name: `Abigail Hive`
+- Runtime surface name: `Entity Runtime`
+- Primary promise: private family AI coordination
+- Visual personality: calm, protective, precise, capable
+
+## Logo and Wordmark
+
+Use text wordmarks until a final logo asset exists.
+
+- Primary wordmark: `Abigail`
+- Control-plane wordmark: `Abigail Hive`
+- Minimum wordmark size: 18 px text height in compact headers, 28 px in startup or empty states.
+- Do not use all-caps wordmarks except short labels and diagnostics.
+- Do not stretch, outline, glow, or skew the wordmark.
+- Do not make `SOUL REGISTRY` the main product headline in family-facing UI. Use `Abigail Hive` and describe registry concepts in supporting UI.
+
+Optional monogram:
+
+```text
+A
+```
+
+- Use only inside a 32 x 32 px or 40 x 40 px square/circle.
+- Background: `--color-bg-elevated`.
+- Foreground: `--color-primary`.
+- Border: `1px solid --color-border`.
+
+## Typography
+
+Default family-facing typography uses Inter with system fallbacks. Monospace is reserved for IDs, logs, code, and short technical metadata.
+
+| Token | Family | Use |
+| --- | --- | --- |
+| `--font-primary` | `Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif` | UI, forms, navigation, body copy |
+| `--font-mono` | `"JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace` | IDs, logs, timestamps, code |
+
+Type scale:
+
+| Role | Size | Line-height | Weight | Tailwind example |
+| --- | ---: | ---: | ---: | --- |
+| Display | 32 px | 40 px | 650 | `text-[32px] leading-10 font-semibold` |
+| Page title | 24 px | 32 px | 650 | `text-2xl leading-8 font-semibold` |
+| Section title | 18 px | 28 px | 600 | `text-lg leading-7 font-semibold` |
+| Body | 15 px | 24 px | 400 | `text-[15px] leading-6` |
+| Body small | 14 px | 22 px | 400 | `text-sm leading-[22px]` |
+| Label | 12 px | 16 px | 600 | `text-xs leading-4 font-semibold` |
+| Metadata | 11 px | 16 px | 500 | `text-[11px] leading-4 font-mono` |
+
+Rules:
+
+- Letter spacing is `0` for body and controls.
+- Uppercase labels may use `0.04em` letter spacing, max 16 characters when possible.
+- Line-height must never be below `1.35`.
+- Do not scale font size with viewport width.
+- Do not use 10 px text for actions. The minimum action text size is 12 px.
+
+## Color Palette
+
+Modern Clean is the default product theme. This is the baseline for first-run and all family-facing screens.
+
+### Modern Clean Tokens
+
+| Token | Hex/RGB | Use |
+| --- | --- | --- |
+| `--color-bg` | `#0F1419` / `rgb(15 20 25)` | App background |
+| `--color-bg-elevated` | `#1A2028` / `rgb(26 32 40)` | Shells, drawers, top bars |
+| `--color-bg-inset` | `#0A0E12` / `rgb(10 14 18)` | Input wells, chat transcript wells |
+| `--color-surface` | `rgba(30, 41, 59, 0.40)` | Cards and panels |
+| `--color-surface-dim` | `rgba(30, 41, 59, 0.20)` | Subtle cards, empty states |
+| `--color-surface-bright` | `rgba(30, 41, 59, 0.60)` | Hovered panels, active rows |
+| `--color-border` | `#334155` / `rgb(51 65 85)` | Default border |
+| `--color-border-dim` | `#1E293B` / `rgb(30 41 59)` | Quiet separators |
+| `--color-text` | `#E2E8F0` / `rgb(226 232 240)` | Main text |
+| `--color-text-bright` | `#F8FAFC` / `rgb(248 250 252)` | Titles and active text |
+| `--color-text-dim` | `#94A3B8` / `rgb(148 163 184)` | Secondary text |
+| `--color-primary` | `#6366F1` / `rgb(99 102 241)` | Primary action/accent |
+| `--color-primary-dim` | `#818CF8` / `rgb(129 140 248)` | Accent text on dark |
+| `--color-primary-muted` | `#4F46E5` / `rgb(79 70 229)` | Pressed/active accent |
+| `--color-primary-faint` | `#3730A3` / `rgb(55 48 163)` | Low-emphasis accent border |
+| `--color-success` | `#22C55E` / `rgb(34 197 94)` | Healthy state |
+| `--color-warning` | `#F59E0B` / `rgb(245 158 11)` | Attention state |
+| `--color-danger` | `#EF4444` / `rgb(239 68 68)` | Destructive/error state |
+| `--color-info` | `#3B82F6` / `rgb(59 130 246)` | Informational state |
+| `--color-focus-ring` | `rgba(99, 102, 241, 0.50)` | Keyboard focus |
+| `--color-overlay` | `rgba(0, 0, 0, 0.60)` | Modal scrim |
+
+State fills:
+
+| Token | Value |
+| --- | --- |
+| `--color-primary-glow` | `rgba(99, 102, 241, 0.15)` |
+| `--color-hover` | `rgba(99, 102, 241, 0.08)` |
+| `--color-success-dim` | `rgba(34, 197, 94, 0.15)` |
+| `--color-warning-dim` | `rgba(245, 158, 11, 0.15)` |
+| `--color-danger-dim` | `rgba(239, 68, 68, 0.15)` |
+| `--color-info-dim` | `rgba(59, 130, 246, 0.15)` |
+
+### Theme Rules
+
+- Default first-run theme: Modern Clean.
+- Phosphor Terminal: allowed for developer diagnostics or a user-selected personality theme only.
+- Classic Desktop: allowed only as an explicit nostalgic theme. Do not use it for default onboarding, registry, provider setup, or family-facing chat.
+- Avoid one-note palettes. Screens need neutral foundations plus restrained accent and state colors.
+- Do not use decorative gradient blobs, floating orbs, or bokeh backgrounds.
+
+## Iconography
+
+Preferred library: `lucide-react` when available. If not installed in a specific package, add it only with a focused UI task.
+
+Icon sizes:
+
+| Context | Size | Stroke |
+| --- | ---: | ---: |
+| Toolbar icon button | 18 px | 1.75 |
+| Primary button leading icon | 16 px | 2 |
+| Empty state | 32 px | 1.5 |
+| Navigation rail | 20 px | 1.75 |
+| Status dot | 8 px | n/a |
+
+Rules:
+
+- Icons must have accessible names when they are the only visible label.
+- Icon-only buttons must be 36 x 36 px minimum on desktop and 44 x 44 px on touch layouts.
+- Do not draw custom SVG icons when a lucide icon exists.
+- Pair status color with text. Color alone is not state.
+
+## Image and Avatar Style
+
+Images should reveal a real product, person, place, or generated Entity identity. Avoid generic stock atmosphere.
+
+Entity avatars:
+
+- Size: 40 px in lists, 64 px in detail panels, 96 px in profile/edit screens.
+- Shape: circle for Entity identity, 8 px rounded square for tools/apps.
+- Border: `1px solid --color-border`.
+- Fallback: first initial or monogram on `--color-bg-inset`.
+- Do not crop faces tighter than forehead-to-chin plus 12 percent margin.
+
+Screenshots:
+
+- Use current UI only.
+- Hide secrets, local file paths, tokens, and private chat content.
+- Prefer 1440 x 900 desktop and 390 x 844 mobile captures.
+
+## Surface, Radius, and Shadow
+
+| Token | Value | Use |
+| --- | ---: | --- |
+| `--radius-sm` | 4 px | Inputs, small chips |
+| `--radius-md` | 6 px | Buttons, compact controls |
+| `--radius-lg` | 10 px | Cards, modals, drawers |
+| `--shadow-elevated` | `0 4px 12px rgba(0, 0, 0, 0.30)` | Modal/card elevation |
+| `--shadow-dropdown` | `0 8px 24px rgba(0, 0, 0, 0.40)` | Popovers |
+
+Rules:
+
+- Cards stay at 8 to 10 px radius. Do not use pill-shaped cards.
+- Do not put cards inside cards.
+- Page sections are unframed layout bands. Cards are for repeated items, modals, and framed tools.
+
+## Visual Anti-Patterns
+
+The screenshot that triggered this guide shows several forbidden states:
+
+- Full-width raw select/status bars.
+- Buttons rendered as default browser rectangles.
+- Labels and metadata colliding with headings.
+- All-caps headings used as the primary product brand.
+- Unbounded rows and timestamps overflowing the viewport.
+- Layout that depends on browser defaults instead of design tokens.
+
+Every production screen must pass this quick visual test: if Tailwind failed to load, the screen should be obviously broken in QA, not quietly shippable.

--- a/docs/design/02-component-style-guide.md
+++ b/docs/design/02-component-style-guide.md
@@ -1,0 +1,285 @@
+# Component-Based Style Guide
+
+Reusable components are the only acceptable way to build Abigail UI. One-off class strings are allowed only while extracting a component in the same pull request.
+
+## Component Contract
+
+Every reusable component must define:
+
+- Purpose and allowed use.
+- Props and event semantics.
+- Loading, empty, error, disabled, hover, focus, active, and selected states.
+- Keyboard behavior.
+- Accessible name and role.
+- Security/privacy notes when it touches user data.
+
+## Buttons
+
+### Variants
+
+| Variant | Use | Base style |
+| --- | --- | --- |
+| Primary | Main forward action | Filled `--color-primary`, white text |
+| Secondary | Alternate action | `--color-bg-elevated`, border |
+| Ghost | Low-emphasis utility | Transparent, hover fill |
+| Danger | Destructive | Danger border/fill, confirm when irreversible |
+| Icon | Toolbar action | Square, icon centered, visible focus |
+
+States:
+
+- Hover: background shifts by one token step, no layout movement.
+- Active: use `--color-primary-muted` or inset transform `translateY(1px)` only.
+- Disabled: opacity `0.45`, cursor `not-allowed`, no tooltip-only explanation.
+- Focus: `2px solid --color-focus-ring`, `outline-offset: 2px`.
+
+Complete React example:
+
+```tsx
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  icon?: ReactNode;
+}
+
+const variants: Record<ButtonVariant, string> = {
+  primary:
+    "bg-theme-primary text-white hover:bg-theme-primary-muted disabled:hover:bg-theme-primary",
+  secondary:
+    "border border-theme-border bg-theme-bg-elevated text-theme-text hover:border-theme-primary hover:bg-theme-hover",
+  ghost:
+    "text-theme-text-dim hover:bg-theme-hover hover:text-theme-text",
+  danger:
+    "border border-theme-danger text-theme-danger hover:bg-theme-danger-dim",
+};
+
+export function Button({
+  variant = "secondary",
+  icon,
+  children,
+  className = "",
+  type = "button",
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={[
+        "inline-flex min-h-9 items-center justify-center gap-2 rounded-theme-md px-3 py-2",
+        "text-sm font-medium transition-colors duration-theme-fast",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-theme-focus-ring",
+        "disabled:cursor-not-allowed disabled:opacity-45",
+        variants[variant],
+        className,
+      ].join(" ")}
+      {...props}
+    >
+      {icon && <span className="grid size-4 place-items-center" aria-hidden="true">{icon}</span>}
+      {children}
+    </button>
+  );
+}
+```
+
+Mockup:
+
+```text
+[ Connect a model ]  [ Secondary action ]  [ Delete ]
+```
+
+## Inputs and Forms
+
+Rules:
+
+- Every input has a visible label.
+- Placeholder text is an example, never the only instruction.
+- Error text appears below the field and is associated with `aria-describedby`.
+- Inputs never span edge-to-edge on large desktop. Use max widths.
+- Do not show secrets in plaintext by default.
+
+Example:
+
+```tsx
+interface TextFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  error?: string;
+  onChange: (value: string) => void;
+}
+
+export function TextField({ id, label, value, placeholder, error, onChange }: TextFieldProps) {
+  const errorId = `${id}-error`;
+
+  return (
+    <div className="grid gap-1.5">
+      <label htmlFor={id} className="text-xs font-semibold text-theme-text">
+        {label}
+      </label>
+      <input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? errorId : undefined}
+        onChange={(event) => onChange(event.target.value)}
+        className={[
+          "min-h-10 rounded-theme-md border bg-theme-input-bg px-3 py-2 text-sm text-theme-text",
+          "placeholder:text-theme-text-dim focus:border-theme-primary focus:outline-none",
+          error ? "border-theme-danger" : "border-theme-border",
+        ].join(" ")}
+      />
+      {error && <p id={errorId} className="text-xs text-theme-danger">{error}</p>}
+    </div>
+  );
+}
+```
+
+## Navigation Bars and Rails
+
+Use horizontal navigation for top-level Hive tasks and a side rail for persistent tools.
+
+Top bar anatomy:
+
+```text
++----------------------------------------------------------------+
+| Abigail Hive        Status: Local model ready     [Connect]     |
++----------------------------------------------------------------+
+```
+
+Rules:
+
+- Height: 56 px desktop, 52 px compact.
+- Padding: 24 px desktop, 16 px tablet, 12 px mobile.
+- Status indicators live on the right, not in a raw select-style strip.
+- The active item must use both text weight and background/border state.
+
+## Modals and Drawers
+
+Use modals for blocking decisions and drawers for setup/configuration.
+
+Required behavior:
+
+- `role="dialog"` and `aria-modal="true"`.
+- Label with `aria-labelledby`.
+- Focus moves into the dialog on open and returns to the trigger on close.
+- `Escape` closes unless the action is destructive or mid-save.
+- Background scroll is locked.
+- Destructive confirmation names the object being changed.
+
+Example shell:
+
+```tsx
+export function ConfirmDeleteDialog({
+  entityName,
+  onCancel,
+  onConfirm,
+}: {
+  entityName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-theme-overlay p-4">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-title"
+        className="w-full max-w-md rounded-theme-lg border border-theme-border bg-theme-bg-elevated p-5 shadow-theme-elevated"
+      >
+        <h2 id="delete-title" className="text-lg font-semibold text-theme-text-bright">
+          Delete {entityName}?
+        </h2>
+        <p className="mt-2 text-sm text-theme-text-dim">
+          This removes the local Entity profile from this Hive. Back up anything you need first.
+        </p>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="secondary" onClick={onCancel}>Cancel</Button>
+          <Button variant="danger" onClick={onConfirm}>Delete Entity</Button>
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+## Dropdowns and Menus
+
+Rules:
+
+- Use native `select` for simple forms with fewer than 8 options.
+- Use custom menu buttons only when options need descriptions, icons, or grouping.
+- Menu opens on Enter, Space, or ArrowDown.
+- Menu items use `role="menuitem"` only when the widget behaves like an app menu. For list selection, use listbox semantics.
+- Width must fit the longest label without truncating critical text.
+
+## Tables and Data Lists
+
+Use tables only for dense comparison. Use cards/lists for Entities and setup tasks.
+
+Table requirements:
+
+- Sticky header when vertical scrolling.
+- Column headers use `scope="col"`.
+- Numeric values align right.
+- Row actions live in the final column.
+- Empty state explains what will appear and how to create the first item.
+
+Example:
+
+```tsx
+<table className="w-full border-separate border-spacing-0 text-sm">
+  <thead className="sticky top-0 bg-theme-bg-elevated">
+    <tr>
+      <th scope="col" className="border-b border-theme-border px-3 py-2 text-left">Provider</th>
+      <th scope="col" className="border-b border-theme-border px-3 py-2 text-left">Status</th>
+      <th scope="col" className="border-b border-theme-border px-3 py-2 text-right">Actions</th>
+    </tr>
+  </thead>
+  <tbody>{rows}</tbody>
+</table>
+```
+
+## Cards
+
+Use cards for repeated Entities, provider choices, backups, and skills.
+
+Rules:
+
+- Radius: `--radius-lg`.
+- Padding: 16 px compact, 20 px standard.
+- Border always present, even when subtle.
+- Whole-card click is allowed only when there are no nested buttons. Otherwise use explicit action buttons.
+- No cards inside cards.
+
+Entity card mockup:
+
+```text
++------------------------------+
+| A  Ada                       |
+|    Ready - local memory      |
+|                              |
+| [Open]       Last active 2m  |
++------------------------------+
+```
+
+## Toasts and Status Messages
+
+Use toasts for temporary feedback and inline status for persistent conditions.
+
+Rules:
+
+- Toast timeout: 5 seconds for success/info, persistent for errors requiring action.
+- Toasts use `role="status"` unless urgent, then `role="alert"`.
+- Never show secrets or full file paths in toast text.
+
+## Implementation Best Practices
+
+- Prefer component props over duplicated class strings.
+- Use semantic HTML first, ARIA second.
+- Keep components controlled from the parent for async operations.
+- Create Storybook-like documentation later using the examples in this guide as fixtures.
+- Add tests for keyboard behavior and accessible names when creating reusable components.

--- a/docs/design/03-interaction-animation-style-guide.md
+++ b/docs/design/03-interaction-animation-style-guide.md
@@ -1,0 +1,148 @@
+# Interaction and Animation Style Guide
+
+Abigail interactions should feel responsive and steady. Motion is used to explain state, not to decorate the screen.
+
+## Timing Tokens
+
+| Token | Duration | Use |
+| --- | ---: | --- |
+| Instant | 0 ms | Reduced motion, terminal/classic themes |
+| Fast | 120-150 ms | Hover, focus, button active |
+| Normal | 200-250 ms | Drawer/modal fade, card selection |
+| Slow | 320-400 ms | Startup transitions, non-blocking panel entrance |
+| Loading loop | 900-1400 ms | Skeleton shimmer, thinking dots |
+
+Current CSS tokens:
+
+```css
+--transition-fast: 150ms;
+--transition-normal: 250ms;
+```
+
+## Easing
+
+Use these curves consistently:
+
+| Name | Curve | Use |
+| --- | --- | --- |
+| Standard | `cubic-bezier(0.2, 0, 0, 1)` | Most UI transitions |
+| Emphasized out | `cubic-bezier(0.16, 1, 0.3, 1)` | Drawer/modal entrance |
+| Emphasized in | `cubic-bezier(0.7, 0, 0.84, 0)` | Drawer/modal exit |
+| Linear | `linear` | Progress bars only |
+
+Do not use spring/bouncy motion for privacy, security, or error states.
+
+## Hover and Press States
+
+Buttons:
+
+- Hover: color/background shift only.
+- Active: optional `transform: translateY(1px)`.
+- Disabled: no hover transform.
+
+Cards:
+
+- Hover border shifts to `--color-primary` only when the card is clickable.
+- Non-clickable cards must not react on hover.
+- Do not animate card dimensions.
+
+Inputs:
+
+- Focus changes border and focus outline.
+- Validation messages appear immediately after blur or submit, not on every keystroke unless the field has already errored.
+
+## Loading Indicators
+
+Use the smallest indicator that explains the wait.
+
+| Wait | Pattern |
+| --- | --- |
+| Under 500 ms | No loader |
+| 500 ms to 2 s | Inline spinner or disabled button text |
+| 2 s to 8 s | Skeleton or progress text |
+| Over 8 s | Progress state with cancel/retry when possible |
+
+Button loading example:
+
+```tsx
+<Button disabled={busy} aria-busy={busy}>
+  {busy ? "Creating..." : "Create Entity"}
+</Button>
+```
+
+Skeleton example:
+
+```tsx
+<div className="grid gap-3" aria-label="Loading Entities">
+  {[0, 1, 2].map((item) => (
+    <div
+      key={item}
+      className="h-24 animate-pulse rounded-theme-lg border border-theme-border-dim bg-theme-surface-dim"
+    />
+  ))}
+</div>
+```
+
+## User Feedback
+
+- Success: quiet inline confirmation or toast.
+- Warning: inline banner with one clear action.
+- Error: plain-language cause plus recovery action.
+- Destructive: confirmation dialog naming the object.
+- Long-running background work: persistent status region, not a blocking modal.
+
+ARIA:
+
+- Non-urgent status: `role="status"`.
+- Error that blocks progress: `role="alert"`.
+- Loading regions: `aria-busy="true"` on the affected region.
+
+## Scroll Behavior
+
+- Main app shell owns page scroll.
+- Drawers and modals have internal scroll only when content exceeds viewport.
+- Preserve scroll position when refreshing data.
+- Use `scroll-margin-top: 80px` for anchored sections under sticky headers.
+- Do not scroll the page on validation unless the errored field is outside the viewport.
+
+## Micro-Interactions
+
+Recommended:
+
+- Provider connection test: inline status changes from `Checking...` to `Connected`.
+- Entity creation: disable button, then add the new Entity card without a full page reload.
+- Chat send: message appears immediately with pending state, then resolves or shows retry.
+- Secret entry: reveal button is momentary or toggled with clear label.
+
+Forbidden:
+
+- Flashing borders.
+- Infinite glow around important actions.
+- Motion that is required to understand state.
+- Hover-only controls.
+- Auto-advancing carousels.
+
+## Reduced Motion
+
+Every motion pattern must respect user preference:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+## Implementation Guidelines
+
+- Use CSS transitions for simple state changes.
+- Use React state for semantic states, not for decorative animation timers.
+- Keep animations interruptible. If state changes, the UI must settle quickly.
+- Use `transform` and `opacity` when animating; avoid animating layout properties.
+- Test with keyboard navigation and reduced motion enabled.

--- a/docs/design/04-accessibility-style-guide.md
+++ b/docs/design/04-accessibility-style-guide.md
@@ -1,0 +1,172 @@
+# Accessibility Style Guide
+
+Baseline: WCAG 2.2 AA. Abigail should be usable with keyboard, screen reader, magnification, reduced motion, and high-contrast preferences.
+
+## Standards
+
+Required external baseline:
+
+- [WCAG 2.2 AA](https://www.w3.org/TR/WCAG22/).
+- WCAG 2.2 contrast, keyboard, focus visible, focus not obscured, target size, status messages, and accessible authentication guidance.
+
+## Color Contrast
+
+Minimums:
+
+- Body text: 4.5:1 contrast ratio.
+- Large text, 18 px bold or 24 px regular: 3:1.
+- Icons, focus indicators, input borders, and charts: 3:1 against adjacent colors.
+- Disabled controls are exempt from contrast requirements but must remain recognizable.
+
+Rules:
+
+- Do not encode status with color alone.
+- Text over images requires a stable overlay or solid background.
+- Focus rings must be visible against both component and page backgrounds.
+
+## Keyboard Navigation
+
+Required behavior:
+
+- Every interactive element is reachable by Tab or documented shortcut.
+- Focus order follows visual order.
+- No keyboard trap. Modals trap focus only while open and release focus on close.
+- `Escape` closes menus, popovers, and non-destructive dialogs.
+- Enter and Space activate buttons.
+- Arrow keys navigate within menus, listboxes, radio groups, and tablists.
+
+Testing checklist:
+
+1. Load the app.
+2. Use Tab from the top of the screen to the bottom.
+3. Confirm the focus indicator is always visible.
+4. Activate every control with keyboard only.
+5. Open and close every dialog with keyboard only.
+6. Confirm focus returns to the trigger.
+
+## Semantic HTML
+
+Use semantic elements before ARIA:
+
+| UI | Element |
+| --- | --- |
+| Page/screen shell | `main` |
+| Top navigation | `nav` |
+| Repeated Entity cards | `ul` and `li` |
+| Buttons | `button` |
+| Links to URLs | `a` |
+| Form field groups | `form`, `fieldset`, `legend` |
+| Data comparison | `table` |
+| Status text | `output`, `p role="status"` |
+
+Bad:
+
+```tsx
+<div onClick={save}>Save</div>
+```
+
+Good:
+
+```tsx
+<button type="button" onClick={save}>Save</button>
+```
+
+## ARIA Rules
+
+- Use ARIA only when native HTML cannot express the interaction.
+- `aria-label` is allowed for icon-only controls.
+- `aria-describedby` connects help and error text.
+- `aria-live="polite"` for non-urgent async updates.
+- `role="alert"` only for errors that immediately affect the user's task.
+- Do not add `role="button"` to a `button`.
+- Visible label and accessible name must match for voice control.
+
+Example field:
+
+```tsx
+<label htmlFor="entity-name">Entity name</label>
+<input
+  id="entity-name"
+  aria-describedby="entity-name-help entity-name-error"
+  aria-invalid={Boolean(error)}
+/>
+<p id="entity-name-help">Use the name your family will say naturally.</p>
+{error && <p id="entity-name-error" role="alert">{error}</p>}
+```
+
+## Target Size
+
+- Preferred target: 44 x 44 px.
+- Minimum desktop target: 36 x 36 px.
+- Minimum touch target: 44 x 44 px.
+- Inline text links may be smaller only inside prose and must have enough spacing from neighboring links.
+
+## Text Readability
+
+- Default body size: 15 px.
+- Minimum UI text: 12 px.
+- Paragraph line length: 45 to 80 characters.
+- Avoid all-caps paragraphs.
+- Keep labels concise and concrete.
+- Support browser zoom up to 200 percent without clipping controls.
+
+## Screen Reader Compatibility
+
+Required patterns:
+
+- Each screen has one `h1`.
+- Heading levels do not skip for visual styling.
+- Loading states announce the affected region.
+- Toasts use `role="status"` or `role="alert"`.
+- Entity cards expose name, status, and action labels.
+- Tables have headers and captions when context is not obvious.
+
+Entity card example:
+
+```tsx
+<li className="rounded-theme-lg border border-theme-border p-4">
+  <h3 className="font-semibold text-theme-text-bright">Ada</h3>
+  <p className="text-sm text-theme-text-dim">Ready. Last active 2 minutes ago.</p>
+  <Button aria-label="Open Ada">Open</Button>
+</li>
+```
+
+## Forms and Errors
+
+- Show errors near the field and summarize at the top for multi-field forms.
+- Error text must say what happened and how to fix it.
+- Do not clear user input after validation fails.
+- Required fields use visible text, not only an asterisk.
+- Secret fields default to hidden text and have an accessible reveal control.
+
+## Motion and Vestibular Safety
+
+- Respect `prefers-reduced-motion`.
+- Avoid parallax and zoom.
+- No flashing more than 3 times per second.
+- Loading animation must not be the only indication of progress.
+
+## Accessibility Testing
+
+Automated:
+
+- React Testing Library queries by role/name.
+- `@testing-library/jest-dom` assertions for disabled, invalid, and described states.
+- Add axe checks when a browser/e2e test lane is established.
+
+Manual:
+
+- Keyboard-only pass.
+- Windows Narrator or NVDA smoke pass.
+- macOS VoiceOver smoke pass when macOS CI/dev is available.
+- 200 percent zoom.
+- Reduced motion.
+- High contrast mode on Windows.
+
+Definition of done:
+
+- No raw clickable `div`.
+- No unlabeled input.
+- No icon-only button without an accessible name.
+- No modal without focus management.
+- No text below minimum contrast.

--- a/docs/design/05-content-writing-style-guide.md
+++ b/docs/design/05-content-writing-style-guide.md
@@ -1,0 +1,173 @@
+# Content and Writing Style Guide
+
+Abigail's voice is calm, capable, and human. The UI should make the family head feel in control without sounding clinical or mystical.
+
+## Voice
+
+| Attribute | Write like this | Avoid |
+| --- | --- | --- |
+| Clear | "Connect a model" | "Configure provider substrate" |
+| Reassuring | "Your data stays on this computer." | "No exfiltration detected." |
+| Direct | "Create Entity" | "Proceed with entity instantiation" |
+| Warm | "Name the Entity your family will talk to." | "Input entity identifier." |
+| Honest | "The Hive is not responding yet." | "Something went wrong." |
+
+## Terminology
+
+Preferred terms:
+
+- `Abigail`
+- `Abigail Hive`
+- `Entity`
+- `family`
+- `mentor` only when referring to the family head's elevated role
+- `model`
+- `provider`
+- `local memory`
+- `backup`
+- `private key`
+
+Avoid in primary UI:
+
+- `soul registry` as the main screen label
+- `birth` when a simpler `Create Entity` works
+- `in-utero`
+- `superego`
+- `id`
+- raw IDs unless in diagnostics or detail views
+
+Developer/research terms can appear in advanced diagnostics, logs, and docs.
+
+## Labels
+
+Rules:
+
+- Button labels start with verbs: `Create`, `Open`, `Connect`, `Retry`, `Back up`.
+- Navigation labels are nouns: `Entities`, `Models`, `Memory`, `Settings`.
+- Labels should be 1 to 3 words.
+- Do not use punctuation in labels unless needed for clarity.
+
+Examples:
+
+| Good | Bad |
+| --- | --- |
+| `Create Entity` | `Birth New Entity` |
+| `Connect a model` | `Configure Providers` |
+| `Open Ada` | `Launch` |
+| `Back up Entity` | `Recover entity from backup` as a primary CTA |
+
+## Helper Text
+
+Use helper text to reduce anxiety:
+
+```text
+Good:
+Use the name your family will say naturally.
+
+Bad:
+Entity name...
+```
+
+Helper text rules:
+
+- One sentence.
+- No more than 120 characters.
+- Explain why, not just what.
+- Do not repeat the label.
+
+## Error Messages
+
+Error formula:
+
+```text
+What happened. What to do next.
+```
+
+Examples:
+
+| Situation | Message |
+| --- | --- |
+| Hive unavailable | `The Hive is not responding yet. Retry in a moment.` |
+| Empty Entity name | `Enter a name before creating an Entity.` |
+| Provider key invalid | `That key was not accepted. Check it and try again.` |
+| Backup restore failed | `The backup could not be restored. Choose another backup or keep the current Entity.` |
+| Network unavailable | `Abigail cannot reach that provider right now. Local models are still available.` |
+
+Security-sensitive errors:
+
+- Do not reveal whether a secret exists.
+- Do not print tokens, keys, local paths, or request payloads.
+- Use a diagnostic code only when it maps to a safe troubleshooting page.
+
+## Tooltips
+
+Tooltips explain controls, not required information.
+
+Rules:
+
+- 1 sentence.
+- Max 90 characters.
+- Available on hover and focus.
+- Never contain secrets or primary instructions.
+- Never be the only way to learn a field requirement.
+
+## Empty States
+
+Pattern:
+
+1. What is empty.
+2. Why it matters.
+3. One action.
+
+Example:
+
+```text
+No Entities yet
+Create the first Entity your family will talk to.
+[Create Entity]
+```
+
+## Dates and Times
+
+Family-facing:
+
+- Recent: `2 minutes ago`, `Yesterday`, `Apr 13 at 9:55 PM`.
+- Full timestamp only in diagnostics.
+
+Diagnostics:
+
+- ISO 8601 with timezone: `2026-04-13T21:55:29-04:00`.
+- Use monospace and allow copy.
+
+## Localization
+
+- Keep strings in complete sentences.
+- Avoid concatenating translated fragments.
+- Avoid idioms that do not translate.
+- Use ICU-style pluralization when localization is added.
+- Do not hard-code date/time formats in components.
+
+## Capitalization and Grammar
+
+- Use sentence case for headings and buttons.
+- Product names keep capitalization: `Abigail Hive`, `Entity Runtime`.
+- Use contractions sparingly: `isn't` is okay in friendly status, but avoid in legal/security copy.
+- Use `you` for the family head. Avoid `user` in UI.
+
+## Privacy Copy
+
+Privacy language should be factual and specific:
+
+```text
+Good:
+This memory stays on this computer.
+
+Bad:
+Your data is totally safe.
+```
+
+Do not overpromise. If a cloud provider is involved, state that clearly:
+
+```text
+Messages sent with this model are processed by OpenAI. Abigail still stores memory locally.
+```

--- a/docs/design/06-code-formatting-conventions-style-guide.md
+++ b/docs/design/06-code-formatting-conventions-style-guide.md
@@ -1,0 +1,197 @@
+# Code Formatting and Conventions Style Guide
+
+This guide covers UI-facing code conventions across `hive-app`, `entity-runtime-app`, and `tauri-app`.
+
+## Stack
+
+- React with TypeScript.
+- Vite.
+- Tailwind CSS using Abigail theme tokens.
+- Rust/Tauri for desktop shell and daemon integration.
+- React Testing Library for UI behavior tests.
+
+## Formatting
+
+TypeScript/React:
+
+- Indentation: 2 spaces.
+- Quotes: double quotes.
+- Semicolons: required.
+- Component files: `.tsx`.
+- Utility files: `.ts`.
+- Max practical line length: 100 characters, but do not contort JSX.
+
+Rust:
+
+- `cargo fmt --all`.
+- `cargo clippy --workspace --exclude abigail-app -- -D warnings` for CI-style checks.
+
+CSS:
+
+- Prefer Tailwind utilities and token classes.
+- Use CSS files for tokens, global reset, keyframes, and reusable component layers only.
+
+## Naming
+
+| Item | Convention | Example |
+| --- | --- | --- |
+| React component | PascalCase | `ProviderWizard` |
+| Hook | camelCase starting with `use` | `useHiveStatus` |
+| Event handler | `handle` + action | `handleCreateEntity` |
+| Boolean prop | `is`, `has`, `can`, `should` | `isOpen`, `canRetry` |
+| Async state | noun + `Status` or `State` | `connectionStatus` |
+| Test file | component + `.test.tsx` | `CreateEntityCard.test.tsx` |
+
+Avoid abbreviations except well-known terms such as `id`, `url`, `api`, and `ui`.
+
+## File Structure
+
+Preferred UI structure:
+
+```text
+src/
+  components/
+    Button.tsx
+    Dialog.tsx
+    EntityCard.tsx
+  lib/
+    daemonClient.ts
+    window.ts
+  chat/
+    chatGateway.ts
+  test/
+    setup.ts
+  App.tsx
+  main.tsx
+  index.css
+```
+
+Rules:
+
+- Shared components should move into a local `components/` folder before duplication spreads.
+- Keep daemon/API clients in `lib/`, not inside components.
+- Components should not import from sibling app roots.
+- If all three UI apps need a component, create a shared package in a dedicated follow-up rather than copy-pasting.
+
+## Imports
+
+Order:
+
+1. React and package imports.
+2. Internal components.
+3. Internal libraries.
+4. Types.
+5. CSS, if any.
+
+Example:
+
+```tsx
+import { useCallback, useState } from "react";
+import { Button } from "./Button";
+import { createEntity } from "../lib/daemonClient";
+import type { EntitySummary } from "../lib/daemonClient";
+```
+
+## Component Practices
+
+Rules:
+
+- Prefer function components.
+- Keep components under roughly 200 lines. Extract subcomponents when behavior becomes hard to scan.
+- Keep async side effects in named functions or hooks.
+- Use `type` or `interface` for props next to the component unless shared.
+- Always specify `type="button"` for non-submit buttons.
+- Do not use array indexes as keys for dynamic data.
+- Do not use inline styles except for safe dynamic values such as an Entity accent color after validation.
+
+Good:
+
+```tsx
+<button type="button" onClick={handleOpen} className="rounded-theme-md ...">
+  Open
+</button>
+```
+
+Bad:
+
+```tsx
+<button onClick={() => openEntity(entity.id)}>Open</button>
+```
+
+## Tailwind Rules
+
+- Use theme tokens: `bg-theme-bg`, `text-theme-text`, `border-theme-border`.
+- Do not hard-code arbitrary colors in JSX except temporary prototypes.
+- Keep class order roughly layout, size, spacing, border, color, typography, state.
+- Extract repeated patterns after the third use.
+- Do not use negative letter spacing.
+- Do not use viewport-width font sizes.
+
+## Comments and Documentation
+
+Use comments for:
+
+- Non-obvious async or security behavior.
+- Browser/Tauri integration quirks.
+- Accessibility decisions that are easy to break.
+
+Avoid comments that restate JSX.
+
+Good:
+
+```tsx
+// The daemon may still be warming up after the shell appears, so retry briefly
+// before showing the user an error state.
+```
+
+Bad:
+
+```tsx
+// Set busy to true.
+setBusy(true);
+```
+
+## Error Handling
+
+- Catch async errors at the UI boundary and display a safe message.
+- Preserve the detailed error for local diagnostics only when it does not contain secrets.
+- Never `alert()` in production UI.
+- Do not log tokens, prompts, private keys, file contents, or full local paths.
+
+## Testing
+
+Required for reusable components:
+
+- Renders with accessible name.
+- Disabled/loading behavior.
+- Keyboard behavior when interactive.
+- Error/empty state.
+- Critical privacy behavior such as hidden secrets.
+
+Example:
+
+```tsx
+it("disables create while the name is empty", () => {
+  render(<CreateEntityCard onCreated={vi.fn()} />);
+  expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+});
+```
+
+## Tooling
+
+Current validation commands:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude abigail-app -- -D warnings
+cargo test --workspace --exclude abigail-app
+npm test
+npm run build
+```
+
+Recommended next additions:
+
+- ESLint with `eslint-plugin-jsx-a11y`.
+- Prettier for TypeScript/Markdown.
+- Stylelint for token-only CSS rules.
+- Axe checks in browser/e2e tests.

--- a/docs/design/07-layout-grid-system-style-guide.md
+++ b/docs/design/07-layout-grid-system-style-guide.md
@@ -1,0 +1,189 @@
+# Layout and Grid System Style Guide
+
+Abigail layout should make repeated work easy: scan, compare, open, adjust, return.
+
+## Spacing Scale
+
+Use a 4 px base grid.
+
+| Token | Value | Tailwind |
+| --- | ---: | --- |
+| 1 | 4 px | `1` |
+| 2 | 8 px | `2` |
+| 3 | 12 px | `3` |
+| 4 | 16 px | `4` |
+| 5 | 20 px | `5` |
+| 6 | 24 px | `6` |
+| 8 | 32 px | `8` |
+| 10 | 40 px | `10` |
+| 12 | 48 px | `12` |
+| 16 | 64 px | `16` |
+
+Rules:
+
+- Compact control gap: 8 px.
+- Form field gap: 6 to 8 px inside a field, 16 px between fields.
+- Card grid gap: 12 px compact, 16 px standard.
+- Screen padding: 16 px mobile, 24 px tablet, 32 px desktop.
+
+## Breakpoints
+
+Use Tailwind defaults unless product research requires otherwise.
+
+| Name | Width | Layout |
+| --- | ---: | --- |
+| Mobile | `< 640px` | Single column, bottom/stacked actions |
+| Small | `640px` | Two-column card grids when content allows |
+| Medium | `768px` | Side panels can appear below or beside content |
+| Large | `1024px` | Persistent Hive sidebar allowed |
+| Extra large | `1280px` | Two-pane Hive + helper chat |
+| 2XL | `1536px` | Wider grids, max content constraints |
+
+## App Shell
+
+Default Hive shell:
+
+```text
++--------------------------------------------------------------+
+| Top bar: Abigail Hive, status, primary action                |
++--------------------------------------+-----------------------+
+| Main workspace                       | Optional helper/chat  |
+| Entity grid, setup cards, panels     | Persistent side pane   |
++--------------------------------------+-----------------------+
+```
+
+Rules:
+
+- Use `h-screen` for desktop app shells.
+- Main workspace scrolls independently from persistent helper/chat.
+- Helper pane width: 340 to 400 px.
+- Top bar height: 56 px.
+- Do not place global navigation in a raw full-width bordered strip.
+
+## Grids
+
+Entity card grid:
+
+```tsx
+<ul
+  className="grid gap-4"
+  style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
+>
+  {entities.map((entity) => <EntityCard key={entity.id} entity={entity} />)}
+</ul>
+```
+
+Rules:
+
+- Entity cards: min 220 px, preferred 240 to 320 px.
+- Provider cards: min 260 px.
+- Settings forms: max width 640 px.
+- Chat transcript: max readable line length 760 px.
+- Do not allow timestamps or IDs to stretch a row beyond the viewport. Truncate or wrap in a details view.
+
+## Responsive Typography
+
+Use fixed type sizes by role. Do not scale type with viewport width.
+
+Mobile adjustments:
+
+- Display becomes page title.
+- Page title remains 24 px unless it wraps badly, then shorten copy.
+- Body remains 15 px.
+- Metadata remains 11 to 12 px but can move to a second line.
+
+## Layout Patterns
+
+### Setup Wizard
+
+```text
++-------------------------------+
+| Step title                    |
+| Helpful sentence              |
+|                               |
+| [ Provider choice cards ]     |
+|                               |
+|              [Back] [Connect] |
++-------------------------------+
+```
+
+- Max width: 720 px.
+- Actions align right on desktop, full-width stack on mobile.
+- Progress indicator is text plus step dots, not a decorative progress bar.
+
+### Entity Detail
+
+```text
++----------------------------------------------+
+| Avatar  Ada                 [Open Chat]      |
+| Status, model, last activity                 |
++---------------------+------------------------+
+| Memory summary      | Model/provider settings|
+| Recent activity     | Safety/privacy controls|
++---------------------+------------------------+
+```
+
+- Two columns at `lg`.
+- Single column below `lg`.
+- Keep destructive controls in a separate section at the end.
+
+### Chat Runtime
+
+```text
++----------------------------------------------+
+| Entity header, status, model                 |
++----------------------------------------------+
+| Messages                                     |
+|                                              |
++----------------------------------------------+
+| Composer                                     |
++----------------------------------------------+
+```
+
+- Header fixed within the app shell.
+- Composer fixed at bottom of chat panel.
+- Messages use max width and side alignment.
+- Streaming responses reserve space for the thinking indicator.
+
+## Fixed Dimensions
+
+Define stable dimensions for:
+
+- Icon buttons.
+- Avatars.
+- Status chips.
+- Toolbars.
+- Chat composer.
+- Navigation bars.
+- Card action rows.
+
+This prevents hover text, loading text, and dynamic labels from shifting layout.
+
+## Empty, Error, and Loading Layouts
+
+Empty state max width: 480 px.
+
+```text
+No Entities yet
+Create the first Entity your family will talk to.
+[Create Entity]
+```
+
+Error state:
+
+- Keep the failed region's dimensions stable.
+- Put retry action next to the message.
+- Preserve any user-entered data.
+
+Loading:
+
+- Use skeletons matching final card dimensions.
+- Do not show a full-screen loader when only a panel is refreshing.
+
+## Mobile Rules
+
+- Primary action appears near the related content, not only in the header.
+- Bottom action bars are allowed for multi-step flows.
+- Avoid hover-dependent controls.
+- Use `min-h-[44px]` for touch controls.
+- Drawers become full-screen sheets below `640px`.

--- a/docs/design/08-security-privacy-style-guide.md
+++ b/docs/design/08-security-privacy-style-guide.md
@@ -1,0 +1,203 @@
+# Security and Privacy Style Guide
+
+Abigail is local-first family software. UI and frontend code must protect private family data, model credentials, local memory, prompts, backups, and Entity boundaries.
+
+## Baselines
+
+- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) for application security expectations.
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/) for input validation, logging, session management, secrets, and secure coding practices.
+- GDPR-style privacy principles where applicable: lawfulness, fairness, transparency, purpose limitation, data minimization, accuracy, storage limitation, integrity, confidentiality, and accountability.
+
+## Data Classification
+
+| Class | Examples | UI rule |
+| --- | --- | --- |
+| Public product data | App version, static docs | Safe to display |
+| Local private data | Entity names, memories, family preferences | Display only in expected local context |
+| Sensitive secrets | API keys, private keys, tokens | Never show by default, never log |
+| Highly sensitive recovery data | Mentor private key, recovery bundle | One-time ceremony, explicit save/backup warnings |
+| Diagnostics | Local paths, daemon errors, IDs | Hide behind advanced/details UI |
+
+## Secure Input Handling
+
+Rules:
+
+- Validate on the client for usability and on the daemon/server for authority.
+- Prefer allowlists for structured fields.
+- Trim names and labels.
+- Limit length for all user-controlled strings.
+- Normalize Unicode where identity comparison matters.
+- Never trust values from local storage, query strings, webviews, or daemon responses without validation.
+
+Example:
+
+```ts
+export function validateEntityName(value: string): string | null {
+  const name = value.trim();
+  if (name.length === 0) return "Enter a name before creating an Entity.";
+  if (name.length > 48) return "Use 48 characters or fewer.";
+  if (!/^[\p{L}\p{N} .'-]+$/u.test(name)) {
+    return "Use letters, numbers, spaces, apostrophes, periods, or hyphens.";
+  }
+  return null;
+}
+```
+
+## Secrets and Credentials
+
+UI requirements:
+
+- Secret inputs use `type="password"` by default.
+- Reveal control has text: `Show key` / `Hide key`.
+- Secret values are never stored in React state longer than necessary.
+- Do not put secrets in URLs, telemetry, localStorage, logs, toast text, screenshots, or error details.
+- Clipboard copy for secrets requires an explicit click and a short-lived success message.
+
+Example:
+
+```tsx
+<label htmlFor="api-key">API key</label>
+<input
+  id="api-key"
+  type={showKey ? "text" : "password"}
+  autoComplete="off"
+  spellCheck={false}
+  value={apiKey}
+  onChange={(event) => setApiKey(event.target.value)}
+/>
+<button type="button" onClick={() => setShowKey((value) => !value)}>
+  {showKey ? "Hide key" : "Show key"}
+</button>
+```
+
+## Error Handling
+
+Safe error pattern:
+
+```ts
+try {
+  await connectProvider(input);
+} catch (error) {
+  console.warn("[ProviderWizard] connect failed", safeErrorCode(error));
+  setError("That provider could not be connected. Check the key and try again.");
+}
+```
+
+Rules:
+
+- User messages should be helpful but not reveal implementation internals.
+- Diagnostic details live behind an advanced disclosure.
+- Do not echo request payloads.
+- Do not distinguish secret existence unless necessary.
+- Retry actions must not duplicate destructive operations.
+
+## Logging
+
+Log:
+
+- Startup phase.
+- Daemon health state.
+- Provider connection result code, not secret.
+- Security-relevant denied action.
+- Backup created/restored with safe identifier.
+
+Do not log:
+
+- API keys, tokens, private keys.
+- Prompt text or chat content unless the user explicitly exports diagnostics.
+- Full local file paths in routine logs.
+- Family member names in remote telemetry.
+- Model raw responses containing private data.
+
+Log shape:
+
+```ts
+console.info("[Hive] provider connection tested", {
+  provider: "openai",
+  result: "success",
+});
+```
+
+## Privacy UX
+
+The UI must make data movement clear:
+
+- Local model: `This stays on this computer.`
+- Cloud provider: `Messages sent with this model are processed by [Provider].`
+- Backup: `This backup may contain private family memory. Store it somewhere safe.`
+- Recovery key: `This is the only time Abigail will show this key.`
+
+Do not claim absolute safety. State concrete behavior.
+
+## Session and Authentication
+
+Current local desktop posture:
+
+- Prefer local OS storage and OS-level user session boundaries.
+- Lock or re-authenticate before showing highly sensitive recovery material.
+- Any future remote account session must use secure, httpOnly cookies or platform-native secure storage, not localStorage tokens.
+- Inactive sensitive dialogs should close or obscure content after a short timeout.
+
+## Entity Boundary Rules
+
+- One Entity must not read another Entity's records accidentally.
+- UI calls must include explicit Entity IDs only when scoped to that Entity.
+- Hive-owned management screens may list Entities, but runtime chat screens should only receive the active Entity context.
+- Cross-Entity actions require explicit wording.
+
+Example:
+
+```text
+Good:
+Share this memory with Ada and Heph?
+
+Bad:
+Sync all memories.
+```
+
+## Configuration Management
+
+- Secrets come from secure stores or explicit user entry.
+- Feature flags must default to safest behavior.
+- Signing/updater release variables remain opt-in.
+- Do not commit `.env` files, generated keys, private backups, or local databases.
+- CI should fail on accidental secret patterns when a scanner is available.
+
+## Secure UI Defaults
+
+- Disable submit while a request is in flight.
+- Use idempotency or in-flight guards for creation actions.
+- Confirm irreversible deletes.
+- Prefer local-only operation when cloud provider setup is incomplete.
+- Sanitize user-provided URLs before opening.
+- Use Tauri APIs through narrow wrappers rather than calling privileged APIs from arbitrary components.
+
+## Recommended Libraries and Tools
+
+Current/near-term:
+
+- TypeScript strictness for UI type safety.
+- React Testing Library for accessible behavior tests.
+- `zod` or equivalent schema validation for structured frontend inputs if added.
+- `eslint-plugin-jsx-a11y` for accessibility linting.
+- `cargo audit`, Dependabot, and GitHub code scanning for dependency/security drift.
+
+Future:
+
+- Secret scanning in CI.
+- SBOM generation for release artifacts.
+- Explicit threat model for Hive, Entity Runtime, and Forge flows.
+
+## Security Review Checklist
+
+Before merging UI that handles private data:
+
+- Inputs are validated and length-limited.
+- Secrets are hidden by default.
+- Errors are safe.
+- Logs are scrubbed.
+- Destructive actions confirm object name.
+- Entity IDs are scoped correctly.
+- Cloud data movement is disclosed.
+- Keyboard and screen reader users can complete the flow.
+- Tests cover disabled/loading/error states.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,39 @@
+# Abigail Design System
+
+This directory is the source of truth for Abigail's product design standards. It exists because the UI must feel like a trusted family coordinator, not an exposed developer console.
+
+## Required Guides
+
+1. [Visual Style Guide](01-visual-style-guide.md)
+2. [Component-Based Style Guide](02-component-style-guide.md)
+3. [Interaction and Animation Style Guide](03-interaction-animation-style-guide.md)
+4. [Accessibility Style Guide](04-accessibility-style-guide.md)
+5. [Content and Writing Style Guide](05-content-writing-style-guide.md)
+6. [Code Formatting and Conventions Style Guide](06-code-formatting-conventions-style-guide.md)
+7. [Layout and Grid System Style Guide](07-layout-grid-system-style-guide.md)
+8. [Security and Privacy Style Guide](08-security-privacy-style-guide.md)
+
+## Product Principles
+
+- Family-first, operator-capable: default surfaces are calm, readable, and helpful. Advanced controls exist, but they do not dominate the first screen.
+- Hive stays present: model/provider management belongs to Abigail Hive, and the Hive shell remains visible while Entity work happens.
+- No raw browser controls: every button, input, select, panel, dialog, table, and status area must use the system patterns in these guides.
+- No accidental terminal UI: terminal, phosphor, and classic desktop treatments are allowed only as explicit themes or diagnostics, not as the default family experience.
+- Local-first trust: the UI must make privacy, local storage, and user control obvious without turning every screen into a security lecture.
+
+## Implementation Sources
+
+The current token implementation lives in:
+
+- `hive-app/src-ui/src/index.css`
+- `entity-runtime-app/src-ui/src/index.css`
+- `tauri-app/src-ui/src/index.css`
+- each app's `tailwind.config.js`
+
+When the docs and implementation disagree, fix the implementation or update this design system in the same pull request. Do not create a one-off component style to "just get the screen done."
+
+## External Standards
+
+- Accessibility baseline: [WCAG 2.2 AA](https://www.w3.org/TR/WCAG22/).
+- Security baseline: [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/), [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/), and Abigail's local-first privacy model.
+- Privacy baseline: data minimization, purpose limitation, storage limitation, and user control.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Abigail — Download</title>
+  <title>Abigail - Download</title>
   <style>
     body { font-family: system-ui, -apple-system, sans-serif; max-width: 36rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
     h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
     p { color: #374151; margin: 0.75rem 0; }
     .cta { display: inline-block; margin: 1rem 0; padding: 0.75rem 1.5rem; background: #2563eb; color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; }
     .cta:hover { background: #1d4ed8; }
+    .cta.unavailable { background: #6b7280; cursor: not-allowed; }
+    .cta.unavailable:hover { background: #6b7280; }
     .others { margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb; }
     .others h2 { font-size: 1rem; font-weight: 600; margin-bottom: 0.5rem; }
     .others ul { list-style: none; padding: 0; margin: 0; }
@@ -25,9 +27,9 @@
   <div class="others">
     <h2>Other downloads</h2>
     <ul>
-      <li><a href="https://github.com/jbcupps/abigail/releases/latest/download/Abigail-windows-x64-setup.exe">Windows (x64)</a> — .exe installer</li>
-      <li><a href="https://github.com/jbcupps/abigail/releases/latest/download/Abigail-macos-x64.dmg">macOS (x64)</a> — .dmg</li>
-      <li><a href="https://github.com/jbcupps/abigail/releases/latest/download/Abigail-linux-x64.deb">Linux (x64)</a> — .deb</li>
+      <li><a href="https://github.com/jbcupps/abigail/releases/latest/download/Abigail-windows-x64-setup.exe">Windows (x64)</a> - .exe installer</li>
+      <li><a href="https://github.com/jbcupps/abigail/releases/latest/download/Abigail-linux-x64.deb">Linux (x64)</a> - .deb</li>
+      <li>macOS - temporarily unavailable while Apple signing is paused</li>
     </ul>
   </div>
   <script>
@@ -35,7 +37,7 @@
       var BASE = 'https://github.com/jbcupps/abigail/releases/latest/download/';
       var links = {
         windows: { url: BASE + 'Abigail-windows-x64-setup.exe', label: 'Download for Windows' },
-        macos:   { url: BASE + 'Abigail-macos-x64.dmg',   label: 'Download for macOS' },
+        macos:   { url: 'https://github.com/jbcupps/abigail/releases/latest', label: 'macOS build temporarily unavailable' },
         linux:   { url: BASE + 'Abigail-linux-x64.deb',   label: 'Download for Linux' }
       };
       var os = 'linux';
@@ -48,6 +50,10 @@
       var el = document.getElementById('main-download');
       el.textContent = info.label;
       el.href = info.url;
+      if (os === 'macos') {
+        el.className += ' unavailable';
+        el.setAttribute('aria-disabled', 'true');
+      }
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Add a comprehensive Abigail design system under docs/design with visual, component, motion, accessibility, content, code convention, layout, and security/privacy guides.
- Link the design system from README so future UI work has an explicit standard.
- Remove the stale macOS DMG download link from the static download page while Apple builds are paused.

## Validation
- Checked touched docs for non-ASCII drift.
- Ran git diff --check.
- Confirmed stale macOS release asset links are gone from release-facing docs.