### PR TITLE
Fix split product release packaging

### DIFF
--- a/.github/workflows/release-fast.yml
+++ b/.github/workflows/release-fast.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_stable_release:
+        description: "Publish the unsigned split-product binaries as the latest GitHub release"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,14 +31,22 @@ jobs:
             target: x86_64-pc-windows-msvc
             hive_binary: target/release/abigail-hive-app.exe
             runtime_binary: target/release/abigail-entity-runtime-app.exe
+            hive_daemon_binary: target/release/hive-daemon.exe
+            entity_daemon_binary: target/release/entity-daemon.exe
             hive_asset_name: Abigail-Hive-windows-x64.exe
             runtime_asset_name: Abigail-Entity-Runtime-windows-x64.exe
+            hive_daemon_asset_name: hive-daemon-windows-x64.exe
+            entity_daemon_asset_name: entity-daemon-windows-x64.exe
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             hive_binary: target/release/abigail-hive-app
             runtime_binary: target/release/abigail-entity-runtime-app
+            hive_daemon_binary: target/release/hive-daemon
+            entity_daemon_binary: target/release/entity-daemon
             hive_asset_name: Abigail-Hive-linux-x64
             runtime_asset_name: Abigail-Entity-Runtime-linux-x64
+            hive_daemon_asset_name: hive-daemon-linux-x64
+            entity_daemon_asset_name: entity-daemon-linux-x64
 
     runs-on: ${{ matrix.platform }}
 
@@ -83,7 +96,11 @@ jobs:
               VERSION="${MAJOR}.${MINOR}.${PATCH}"
             fi
           fi
-          TAG="v${VERSION}-stabilization.${{ github.run_number }}"
+          if [[ "${{ github.event.inputs.publish_stable_release }}" == "true" ]]; then
+            TAG="v${VERSION}"
+          else
+            TAG="v${VERSION}-stabilization.${{ github.run_number }}"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
@@ -99,8 +116,8 @@ jobs:
       - name: Verify unsigned stabilization lane
         run: node scripts/check_unsigned_stabilization.mjs
 
-      - name: Build unsigned Hive and Runtime apps
-        run: cargo build --release -p abigail-hive-app -p abigail-entity-runtime-app
+      - name: Build unsigned split product
+        run: cargo build --release -p hive-daemon -p entity-daemon -p abigail-hive-app -p abigail-entity-runtime-app
 
       - name: Stage stabilization binaries
         shell: bash
@@ -108,6 +125,8 @@ jobs:
           mkdir -p stabilization-assets
           cp "${{ matrix.hive_binary }}" "stabilization-assets/${{ matrix.hive_asset_name }}"
           cp "${{ matrix.runtime_binary }}" "stabilization-assets/${{ matrix.runtime_asset_name }}"
+          cp "${{ matrix.hive_daemon_binary }}" "stabilization-assets/${{ matrix.hive_daemon_asset_name }}"
+          cp "${{ matrix.entity_daemon_binary }}" "stabilization-assets/${{ matrix.entity_daemon_asset_name }}"
           ls -la stabilization-assets
 
       - name: Upload stabilization artifacts
@@ -119,7 +138,7 @@ jobs:
 
   publish:
     needs: build
-    if: github.event.inputs.publish_prerelease == 'true' && needs.build.result == 'success'
+    if: (github.event.inputs.publish_prerelease == 'true' || github.event.inputs.publish_stable_release == 'true') && needs.build.result == 'success'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -156,16 +175,31 @@ jobs:
             git push origin "$TAG"
           fi
 
-      - name: Create GitHub pre-release
+      - name: Create release metadata
+        id: release_meta
+        if: steps.artifacts.outputs.count != '0'
+        shell: bash
+        run: |
+          if [[ "${{ github.event.inputs.publish_stable_release }}" == "true" ]]; then
+            echo "name=Abigail v${{ needs.build.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=Abigail Stabilization ${{ needs.build.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
         if: steps.artifacts.outputs.count != '0'
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ needs.build.outputs.tag }}
-          name: Abigail Stabilization ${{ needs.build.outputs.version }}
-          prerelease: true
+          name: ${{ steps.release_meta.outputs.name }}
+          prerelease: ${{ steps.release_meta.outputs.prerelease }}
           draft: false
           body: |
-            Unsigned stabilization binaries for the split Abigail Hive and Abigail Entity Runtime apps.
+            Unsigned binaries for the split Abigail Hive and Abigail Entity Runtime apps.
+
+            Download all four files for your platform into the same directory, then launch Abigail Hive.
 
             This lane intentionally excludes updater artifacts, installer migration logic, and release signing.
           files: |

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -67,3 +67,18 @@ gh workflow run release-fast.yml --ref main -f release_version=0.0.73 -f publish
 ```
 
 Set `publish_prerelease=true` only when you want those unsigned binaries published as a GitHub pre-release.
+
+Publish the current split Hive + Entity Runtime product as the latest unsigned release:
+
+```bash
+gh workflow run release-fast.yml --ref main -f release_version=0.0.74 -f publish_stable_release=true
+```
+
+The split product release uploads four side-by-side binaries for each platform:
+
+- Abigail Hive app
+- Abigail Entity Runtime app
+- hive-daemon
+- entity-daemon
+
+Users must keep the four files for their platform in the same directory and launch Abigail Hive.

--- a/scripts/check_unsigned_stabilization.mjs
+++ b/scripts/check_unsigned_stabilization.mjs
@@ -58,8 +58,25 @@ for (const forbidden of [
   );
 }
 assert(
-  releaseFast.includes("cargo build --release -p abigail-hive-app -p abigail-entity-runtime-app"),
-  "Unsigned stabilization workflow must build the split Hive and Entity Runtime apps."
+  releaseFast.includes(
+    "cargo build --release -p hive-daemon -p entity-daemon -p abigail-hive-app -p abigail-entity-runtime-app"
+  ),
+  "Unsigned stabilization workflow must build the full split product."
+);
+for (const requiredAsset of [
+  "hive-daemon-windows-x64.exe",
+  "entity-daemon-windows-x64.exe",
+  "hive-daemon-linux-x64",
+  "entity-daemon-linux-x64",
+]) {
+  assert(
+    releaseFast.includes(requiredAsset),
+    `Unsigned stabilization workflow must ship side-by-side daemon binary ${requiredAsset}.`
+  );
+}
+assert(
+  releaseFast.includes("publish_stable_release"),
+  "Unsigned stabilization workflow must be able to publish a corrected stable split-product release."
 );
 
 const release = fs.readFileSync(".github/workflows/release.yml", "utf8");


### PR DESCRIPTION
## Summary
- make the unsigned split release lane package the full runnable split product: Hive app, Entity Runtime app, hive-daemon, and entity-daemon
- add stable publish mode so the corrected split-product build can become the latest GitHub release
- update the release guard script and runbook so this old-lane regression is caught next time

## Root cause
The v0.0.73 release was built from current main, but release.yml still packages the legacy tauri-app installer. That makes the published installer look like an older product surface. The current split product lives in hive-app plus entity-runtime-app and needs both daemons beside the app binaries.

## Validation
- node scripts/check_unsigned_stabilization.mjs
- git diff --check